### PR TITLE
feat: actions-timeline v3 を導入しワークフロー実行時間を可視化

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,0 @@
-# Next.js が自動生成するファイル（PR の差分レビューで非表示にする）
-# https://nextjs.org/docs/app/api-reference/config/typescript
-apps/web/next-env.d.ts linguist-generated=true

--- a/.github/workflows/_playwright-test.yml
+++ b/.github/workflows/_playwright-test.yml
@@ -300,3 +300,15 @@ jobs:
             | reg-cli | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/${{ inputs.test-type }}/reg-report/report/ |
             | Playwright HTML | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/${{ inputs.test-type }}/html-report/ |
             | Allure | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/${{ inputs.test-type }}/allure-report/ |
+
+  # ────────────────────────────────────────
+  # ワークフロー実行タイムライン可視化
+  # ────────────────────────────────────────
+  actions-timeline:
+    name: Actions Timeline
+    needs: [test, deploy]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: Kesin11/actions-timeline@v3
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -25,6 +25,7 @@ jobs:
       report-script: vrt:report:reg
       report-title: 📸 Storybook VRT Report
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     secrets: inherit

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -27,6 +27,7 @@ jobs:
       report-script: e2e:report:reg
       report-title: 🧪 E2E Test Report
     permissions:
+      actions: read
       contents: write
       pull-requests: write
     secrets: inherit

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  // ==============================
+  // scripts/ 用 TypeScript 設定
+  // ==============================
+  // - ルートの tsconfig.json を継承し、Bun スクリプト向けの設定のみ上書きする
+  // - ルートの strict 系オプションを緩める変更は禁止（型安全性が低下する）
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    // Bun がモジュール解決を行うため bundler モードを使用
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+
+    // 自動取り込みする型定義（ルートの types: [] を上書き）
+    "types": ["bun"]
+  },
+  "include": ["./**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- CI / VRT / E2E の各ワークフローに [Kesin11/actions-timeline@v3](https://github.com/Kesin11/actions-timeline) を追加し、Run Summary ページでジョブのタイムラインを確認できるようにした
- VRT / E2E ワークフローに `actions: read` パーミッションを追加（actions-timeline が GitHub API でジョブ情報を取得するために必要）
- `scripts/tsconfig.json` を追加し、`scripts/check-bun-version.ts` の型エラーを解消
- `.gitignore` で除外済みの `next-env.d.ts` に対する不要な `.gitattributes` を削除

## Test plan
- [ ] CI ワークフローが正常に完了し、Run Summary にタイムラインが表示されることを確認
- [ ] VRT / E2E ワークフローが正常に完了し、Run Summary にタイムラインが表示されることを確認
- [ ] `bun run typecheck` がエラーなく通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)