### PR TITLE
feat: workflow-telemetry-action v2 を導入し CI リソース使用量を可視化

### DIFF
--- a/.github/workflows/_playwright-test.yml
+++ b/.github/workflows/_playwright-test.yml
@@ -58,6 +58,8 @@ jobs:
       # セットアップ
       # ────────────────────────────────────────
 
+      - uses: catchpoint/workflow-telemetry-action@v2
+
       - uses: actions/checkout@v6
         with:
           # ベースライン生成で base branch を参照するため全履歴が必要

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,18 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+
 jobs:
   ci:
     name: Lint / Typecheck / Knip / Test / Build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      - uses: catchpoint/workflow-telemetry-action@v2
       - uses: Kesin11/actions-timeline@v3
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- CI / VRT / E2E の各ワークフローに [catchpoint/workflow-telemetry-action@v2](https://github.com/catchpoint/workflow-telemetry-action) を追加
- Run Summary と PR コメントで CPU・メモリ・ディスク I/O 等のリソースメトリクスを確認できるようにした
- `ci.yml` に `permissions` ブロックを追加（`actions: read` は actions-timeline 用、`pull-requests: write` はテレメトリの PR コメント用）

## Test plan
- [ ] CI ワークフローの Run Summary にリソースメトリクスのグラフが表示されることを確認
- [ ] VRT / E2E ワークフローの Run Summary にリソースメトリクスのグラフが表示されることを確認
- [ ] PR にテレメトリのコメントが投稿されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)