### PR TITLE
fix: cleanup-pages ワークフローにタイムアウトを設定

### DIFF
--- a/.github/workflows/cleanup-pages.yml
+++ b/.github/workflows/cleanup-pages.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   cleanup:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Summary
- `cleanup-pages.yml` の `cleanup` ジョブに `timeout-minutes: 10` を追加
- 他の全ワークフローにはタイムアウトが設定済みだったが、このワークフローのみ未設定だった

## Test plan
- [ ] ワークフロー構文に問題がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)