### PR TITLE
feat: GitHub Actions のダイジェストピン留めを有効化

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -30,14 +30,13 @@
       matchPackageNames: ["*"],
     },
 
-    // GitHub Actions のダイジェストピン留めを無効化
+    // GitHub Actions のダイジェストピン留めを有効化（config:best-practices のデフォルト）
     // ※ タグはリポジトリオーナーが上書き可能なため、サプライチェーン攻撃のリスクあり
-    //    ダイジェストピン留め（例: actions/checkout@abcdef...）の方が安全だが、
-    //    可読性・メンテナンス性とのトレードオフで無効化している
-    {
-      matchManagers: ["github-actions"],
-      pinDigests: false,
-    },
+    //    ダイジェストピン留め（例: actions/checkout@abcdef...）で改ざんを防止する
+    // {
+    //   matchManagers: ["github-actions"],
+    //   pinDigests: false,
+    // },
 
     // pin タイプの更新を無効化（既存のキャレットレンジを維持）
     // ※ pin されるとレンジが固定値になり、マイナー/パッチの更新 PR が


### PR DESCRIPTION
## Summary
- Renovate の `pinDigests: false` をコメントアウトし、`config:best-practices` のデフォルト（`helpers:pinGitHubActionDigests`）に戻す
- サプライチェーン攻撃のリスクを加味し、可読性よりセキュリティを優先する
- Renovate が既存の GitHub Actions タグをダイジェスト付きに自動変換する PR を作成してくれる

## Test plan
- [ ] Renovate が GitHub Actions のダイジェストピン留め PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)