### PR TITLE
feat: Renovate の minor/patch 更新を自動マージ

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -25,10 +25,16 @@
   enabled: true,
 
   packageRules: [
-    // automerge を無効化（すべての更新を手動レビュー）
+    // マイナー・パッチは CI 通過後に自動マージ
     {
+      matchUpdateTypes: ["minor", "patch", "digest"],
+      automerge: true,
+    },
+
+    // メジャーアップデートは手動レビュー
+    {
+      matchUpdateTypes: ["major"],
       automerge: false,
-      matchPackageNames: ["*"],
     },
 
     // GitHub Actions のダイジェストピン留めを有効化（config:best-practices のデフォルト）
@@ -58,7 +64,7 @@
   prHourlyLimit: 0,
   prConcurrentLimit: 10,
   labels: [],
-  draftPR: true,
+  draftPR: false,
 
   // コミットメッセージ: "chore: [Renovate] update {{depName}}"
   commitMessagePrefix: "chore:",


### PR DESCRIPTION
## Summary
- Renovate の minor/patch/digest 更新を CI 通過後に自動マージするよう設定変更
- メジャーアップデートは引き続き手動レビュー
- Draft PR を無効化（Draft PR では automerge が動作しないため）

## Test plan
- [ ] Renovate が次回の PR を Draft ではなく通常 PR として作成することを確認
- [ ] CI 通過後に自動マージされることを確認

closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)