### PR TITLE
feat: paths フィルタをジョブレベル skip に移行し required status checks に対応

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -1,6 +1,9 @@
 # ==============================================
 # インフラ CI ワークフロー
 # ==============================================
+# 全 PR で起動し、paths-filter でジョブレベル skip する。
+# skip されたジョブは GitHub 上で pass 扱いになるため、
+# required status checks と paths フィルタを両立できる。
 # infra/ 配下の Terraform モジュールに対して
 # フォーマット・バリデーション・リント・plan を実行する。
 #
@@ -34,9 +37,6 @@ name: Infra CI
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "infra/**"
-      - ".github/workflows/infra-ci.yml"
   workflow_dispatch:
 
 permissions:
@@ -44,9 +44,26 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.filter.outputs.infra }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            infra:
+              - 'infra/**'
+              - '.github/workflows/infra-ci.yml'
+
   # ── 静的解析（Secrets 不要） ──
   lint:
     name: Terraform Format / Validate / Lint
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -79,7 +96,8 @@ jobs:
   # ── Plan + apply 漏れ検出（Secrets 必要） ──
   plan:
     name: Terraform Plan
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:

--- a/.github/workflows/storybook-chromatic-deploy.yml
+++ b/.github/workflows/storybook-chromatic-deploy.yml
@@ -2,8 +2,10 @@
 # Storybook Chromatic デプロイワークフロー
 # ==============================================
 # Storybook を Chromatic へデプロイする。
-# - main push 時: プロダクションデプロイ
-# - PR 時: プレビューデプロイ + PR コメントでリンク共有
+# - main push 時: プロダクションデプロイ（paths フィルタで対象を限定）
+# - PR 時: 全 PR で起動し、paths-filter でジョブレベル skip する
+#   skip されたジョブは GitHub 上で pass 扱いになるため、
+#   required status checks と paths フィルタを両立できる。
 # ビジュアルテストは storybook-addon-vis + reg-cli で構築済みのため、
 # Chromatic は Storybook ホスティング専用として使用する。
 #
@@ -24,12 +26,9 @@ on:
       - "packages/ui/**"
       - "bun.lock"
       - ".github/workflows/storybook-chromatic-deploy.yml"
-  # PR 時: プレビューデプロイを作成し、PR コメントでリンクを共有
+  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック
   pull_request:
-    paths:
-      - "packages/ui/**"
-      - "bun.lock"
-      - ".github/workflows/storybook-chromatic-deploy.yml"
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -37,8 +36,26 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            ui:
+              - 'packages/ui/**'
+              - 'bun.lock'
+              - '.github/workflows/storybook-chromatic-deploy.yml'
+
   deploy:
     name: Deploy to Chromatic
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/storybook-cloudflare-deploy.yml
+++ b/.github/workflows/storybook-cloudflare-deploy.yml
@@ -2,8 +2,10 @@
 # Storybook Cloudflare Pages デプロイワークフロー
 # ==============================================
 # Storybook を Cloudflare Pages へデプロイする。
-# - main push 時: プロダクションデプロイ
-# - PR 時: プレビューデプロイ + PR コメントでリンク共有
+# - main push 時: プロダクションデプロイ（paths フィルタで対象を限定）
+# - PR 時: 全 PR で起動し、paths-filter でジョブレベル skip する
+#   skip されたジョブは GitHub 上で pass 扱いになるため、
+#   required status checks と paths フィルタを両立できる。
 # Cloudflare Access (Zero Trust) で認証を設定し、
 # 許可されたユーザーのみがアクセスできるようにする。
 #
@@ -29,12 +31,9 @@ on:
       - "packages/ui/**"
       - "bun.lock"
       - ".github/workflows/storybook-cloudflare-deploy.yml"
-  # PR 時: プレビューデプロイを作成し、PR コメントでリンクを共有
+  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック
   pull_request:
-    paths:
-      - "packages/ui/**"
-      - "bun.lock"
-      - ".github/workflows/storybook-cloudflare-deploy.yml"
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -42,8 +41,26 @@ permissions:
   pull-requests: write
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            ui:
+              - 'packages/ui/**'
+              - 'bun.lock'
+              - '.github/workflows/storybook-cloudflare-deploy.yml'
+
   deploy:
     name: Deploy to Cloudflare Pages
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -1,6 +1,8 @@
 # Storybook VRT（ビジュアルリグレッションテスト）ワークフロー
 #
-# packages/ui/ 配下のファイルが変更された PR で自動実行される。
+# 全 PR で起動し、paths-filter でジョブレベル skip する。
+# skip されたジョブは GitHub 上で pass 扱いになるため、
+# required status checks と paths フィルタを両立できる。
 # storybook-addon-vis + vitest browser mode でスクリーンショットを撮影し、
 # reg-cli で差分レポートを生成する。Storybook ビルド不要。
 name: Storybook VRT
@@ -8,11 +10,6 @@ name: Storybook VRT
 on:
   pull_request:
     branches: [main]
-    # packages/ui/ または bun.lock の変更時のみ実行
-    paths:
-      - "packages/ui/**"
-      - "bun.lock"
-      - ".github/workflows/storybook-vrt.yml"
   workflow_dispatch:
 
 permissions:
@@ -27,8 +24,32 @@ env:
   REPORT_PREFIX: ${{ github.event.pull_request.number && format('pr/{0}', github.event.pull_request.number) || format('manual/{0}', github.run_id) }}
 
 jobs:
+  # ────────────────────────────────────────
+  # 変更検出（dorny/paths-filter）
+  # ────────────────────────────────────────
+  # paths フィルタをワークフローレベルではなくジョブレベルで適用する。
+  # ジョブの skip は GitHub 上で pass 扱いになるため、
+  # required status checks でマージがブロックされない。
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.filter.outputs.ui }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            ui:
+              - 'packages/ui/**'
+              - 'bun.lock'
+              - '.github/workflows/storybook-vrt.yml'
+
   test:
     name: "\U0001F4F8 Storybook VRT"
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -164,8 +185,8 @@ jobs:
   # ────────────────────────────────────────
   deploy:
     name: "Deploy \U0001F4F8 Storybook VRT Report"
-    needs: test
-    if: ${{ !cancelled() }}
+    needs: [changes, test]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # gh-pages ブランチへの push が競合しないようにキューイング
@@ -206,8 +227,8 @@ jobs:
   # ────────────────────────────────────────
   actions-timeline:
     name: Actions Timeline
-    needs: [test, deploy]
-    if: ${{ !cancelled() }}
+    needs: [changes, test, deploy]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -1,6 +1,8 @@
 # E2E テストワークフロー
 #
-# apps/web/ または packages/ui/ 配下のファイルが変更された PR で自動実行される。
+# 全 PR で起動し、paths-filter でジョブレベル skip する。
+# skip されたジョブは GitHub 上で pass 扱いになるため、
+# required status checks と paths フィルタを両立できる。
 # Next.js アプリをビルドし、Playwright でページ遷移やレスポンシブ表示などを検証する。
 # PR 時はベースブランチからベースラインを動的生成し、reg-cli で差分レポートを生成する。
 name: E2E Tests
@@ -8,13 +10,6 @@ name: E2E Tests
 on:
   pull_request:
     branches: [main]
-    # apps/web/、packages/ui/、または bun.lock の変更時に実行
-    # UI コンポーネントの変更が Web アプリに影響する可能性があるため両方を監視
-    paths:
-      - "apps/web/**"
-      - "packages/ui/**"
-      - "bun.lock"
-      - ".github/workflows/web-e2e.yml"
   workflow_dispatch:
 
 permissions:
@@ -29,8 +24,27 @@ env:
   REPORT_PREFIX: ${{ github.event.pull_request.number && format('pr/{0}', github.event.pull_request.number) || format('manual/{0}', github.run_id) }}
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      should-run: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            app:
+              - 'apps/web/**'
+              - 'packages/ui/**'
+              - 'bun.lock'
+              - '.github/workflows/web-e2e.yml'
+
   test:
     name: "\U0001F9EA E2E Test Report"
+    needs: changes
+    if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     outputs:
@@ -230,8 +244,8 @@ jobs:
   # ────────────────────────────────────────
   deploy:
     name: "Deploy \U0001F9EA E2E Test Report"
-    needs: test
-    if: ${{ !cancelled() }}
+    needs: [changes, test]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # gh-pages ブランチへの push が競合しないようにキューイング
@@ -279,8 +293,8 @@ jobs:
   # ────────────────────────────────────────
   actions-timeline:
     name: Actions Timeline
-    needs: [test, deploy]
-    if: ${{ !cancelled() }}
+    needs: [changes, test, deploy]
+    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/README.md
+++ b/README.md
@@ -265,12 +265,14 @@ bun run web:e2e:allure
 PR 作成時に GitHub Actions が自動実行されます。
 
 - **CI** (`ci.yml`): 全 PR で Lint / Typecheck / Knip / Test / Build を実行
-- **Infra CI** (`infra-ci.yml`): `infra/` の変更時に Terraform Format / Validate / tflint を実行
-- **Storybook VRT** (`storybook-vrt.yml`): `packages/ui/` の変更時に実行
-- **E2E テスト** (`web-e2e.yml`): `apps/web/` または `packages/ui/` の変更時に実行
-- **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ
-- **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（Cloudflare Access による認証付き）
+- **Infra CI** (`infra-ci.yml`): 全 PR で起動し、`infra/` の変更時のみ Terraform Format / Validate / tflint を実行（変更なしの場合はジョブ skip = pass）
+- **Storybook VRT** (`storybook-vrt.yml`): 全 PR で起動し、`packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
+- **E2E テスト** (`web-e2e.yml`): 全 PR で起動し、`apps/web/` または `packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
+- **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
+- **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
 - **Cleanup GitHub Pages** (`github-pages-cleanup.yml`): PR クローズ時に gh-pages の容量をチェックし、800MB 超過時に古いレポートを削除
+
+> **Note:** paths フィルタ付きワークフロー（VRT, E2E, Chromatic, Cloudflare, Infra CI）は全 PR で起動し、[dorny/paths-filter](https://github.com/dorny/paths-filter) でジョブレベル skip する設計です。ワークフローレベルの `paths:` だとチェックが「存在しない」状態になり required status checks でマージがブロックされますが、ジョブレベル skip は GitHub 上で pass 扱いになるためこの問題を回避できます。
 
 ### Storybook ホスティング
 


### PR DESCRIPTION
## Summary
- ワークフローレベルの `paths:` フィルタを `dorny/paths-filter` によるジョブレベル skip に移行
- skip されたジョブは GitHub 上で pass 扱いになるため、全チェックを required status checks に設定可能
- 対象: storybook-vrt, web-e2e, storybook-chromatic-deploy, storybook-cloudflare-deploy, infra-ci
- main push 時の paths フィルタは従来どおり維持（プロダクションデプロイに影響なし）
- README の CI/CD セクションを更新

## Test plan
- [ ] CI パス確認
- [ ] paths に該当しない変更のみの PR で、各ジョブが skip（pass）になることを確認
- [ ] paths に該当する変更を含む PR で、各ジョブが正常に実行されることを確認
- [ ] この PR マージ後、required status checks を gh API で設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)