### PR TITLE
feat: ワークフロー絵文字 + Draft PR skip + required status checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,18 @@
 # セクション構成は ci スクリプト・lefthook pre-push と統一:
 #   静的解析 → ランタイム → 統合
 # ==============================================
-name: CI
+name: ✅ CI
 
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 jobs:
   ci:
-    name: Lint / Syncpack / Typecheck / Knip / Test / Build
+    name: ✅ Lint / Syncpack / Typecheck / Knip / Test / Build
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/github-pages-cleanup.yml
+++ b/.github/workflows/github-pages-cleanup.yml
@@ -5,7 +5,7 @@
 # 削除順: 不明なディレクトリ → manual/（手動実行）→ pr/（PR レポート）の優先度で古い順に削除。
 # latest/ は共有の Allure 履歴を保持するため削除しない。
 # レポートは可能な限り残しておき、容量が逼迫した場合にだけクリーンアップする。
-name: Cleanup GitHub Pages
+name: 🧹 Cleanup GitHub Pages
 
 on:
   pull_request:

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -32,11 +32,12 @@
 #   hashicorp/setup-terraform + tfcmt に移行した。
 #   ref: https://github.com/dflook/terraform-github-actions/issues/295
 # ==============================================
-name: Infra CI
+name: 🏗️ Infra CI
 
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -45,6 +46,7 @@ permissions:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -61,7 +63,7 @@ jobs:
 
   # ── 静的解析（Secrets 不要） ──
   lint:
-    name: Terraform Format / Validate / Lint
+    name: 🏗️ Terraform Format / Validate / Lint
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -95,7 +97,7 @@ jobs:
 
   # ── Plan + apply 漏れ検出（Secrets 必要） ──
   plan:
-    name: Terraform Plan
+    name: 🏗️ Terraform Plan
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-chromatic-deploy.yml
+++ b/.github/workflows/storybook-chromatic-deploy.yml
@@ -16,7 +16,7 @@
 # 公式ドキュメント:
 #   https://www.chromatic.com/docs/github-actions/
 # ==============================================
-name: Storybook Chromatic Deploy
+name: 🟣 Storybook Chromatic Deploy
 
 on:
   # main push 時: Chromatic へプロダクションデプロイ
@@ -26,9 +26,10 @@ on:
       - "packages/ui/**"
       - "bun.lock"
       - ".github/workflows/storybook-chromatic-deploy.yml"
-  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック
+  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック（Draft PR は skip）
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -37,6 +38,7 @@ permissions:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -53,7 +55,7 @@ jobs:
               - '.github/workflows/storybook-chromatic-deploy.yml'
 
   deploy:
-    name: Deploy to Chromatic
+    name: 🟣 Deploy to Chromatic
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-cloudflare-deploy.yml
+++ b/.github/workflows/storybook-cloudflare-deploy.yml
@@ -21,7 +21,7 @@
 #     bunx wrangler pages project create <project-name> --production-branch main
 #   Cloudflare Access: Zero Trust > Access > Applications で認証ポリシーを設定
 # ==============================================
-name: Storybook Cloudflare Pages Deploy
+name: 🔶 Storybook Cloudflare Pages Deploy
 
 on:
   # main push 時: プロダクションデプロイ
@@ -31,9 +31,10 @@ on:
       - "packages/ui/**"
       - "bun.lock"
       - ".github/workflows/storybook-cloudflare-deploy.yml"
-  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック
+  # PR 時: 全 PR で起動し、changes ジョブで paths をチェック（Draft PR は skip）
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -42,6 +43,7 @@ permissions:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:
@@ -58,7 +60,7 @@ jobs:
               - '.github/workflows/storybook-cloudflare-deploy.yml'
 
   deploy:
-    name: Deploy to Cloudflare Pages
+    name: 🔶 Deploy to Cloudflare Pages
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -5,11 +5,12 @@
 # required status checks と paths フィルタを両立できる。
 # storybook-addon-vis + vitest browser mode でスクリーンショットを撮影し、
 # reg-cli で差分レポートを生成する。Storybook ビルド不要。
-name: Storybook VRT
+name: 📸 Storybook VRT
 
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -31,6 +32,7 @@ jobs:
   # ジョブの skip は GitHub 上で pass 扱いになるため、
   # required status checks でマージがブロックされない。
   changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -5,11 +5,12 @@
 # required status checks と paths フィルタを両立できる。
 # Next.js アプリをビルドし、Playwright でページ遷移やレスポンシブ表示などを検証する。
 # PR 時はベースブランチからベースラインを動的生成し、reg-cli で差分レポートを生成する。
-name: E2E Tests
+name: 🧪 E2E Tests
 
 on:
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -25,6 +26,7 @@ env:
 
 jobs:
   changes:
+    if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
     outputs:

--- a/README.md
+++ b/README.md
@@ -262,17 +262,19 @@ bun run web:e2e:allure
 
 ## CI/CD
 
-PR 作成時に GitHub Actions が自動実行されます。
+PR 作成時（Ready for review）に GitHub Actions が自動実行されます。Draft PR では CI は実行されず、Ready に変更された時点でトリガーされます。
 
-- **CI** (`ci.yml`): 全 PR で Lint / Typecheck / Knip / Test / Build を実行
-- **Infra CI** (`infra-ci.yml`): 全 PR で起動し、`infra/` の変更時のみ Terraform Format / Validate / tflint を実行（変更なしの場合はジョブ skip = pass）
-- **Storybook VRT** (`storybook-vrt.yml`): 全 PR で起動し、`packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
-- **E2E テスト** (`web-e2e.yml`): 全 PR で起動し、`apps/web/` または `packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
-- **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
-- **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
-- **Cleanup GitHub Pages** (`github-pages-cleanup.yml`): PR クローズ時に gh-pages の容量をチェックし、800MB 超過時に古いレポートを削除
+- ✅ **CI** (`ci.yml`): 全 PR で Lint / Typecheck / Knip / Test / Build を実行
+- 🏗️ **Infra CI** (`infra-ci.yml`): 全 PR で起動し、`infra/` の変更時のみ Terraform Format / Validate / tflint を実行（変更なしの場合はジョブ skip = pass）
+- 📸 **Storybook VRT** (`storybook-vrt.yml`): 全 PR で起動し、`packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
+- 🧪 **E2E テスト** (`web-e2e.yml`): 全 PR で起動し、`apps/web/` または `packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
+- 🟣 **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
+- 🔶 **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
+- 🧹 **Cleanup GitHub Pages** (`github-pages-cleanup.yml`): PR クローズ時に gh-pages の容量をチェックし、800MB 超過時に古いレポートを削除
 
 > **Note:** paths フィルタ付きワークフロー（VRT, E2E, Chromatic, Cloudflare, Infra CI）は全 PR で起動し、[dorny/paths-filter](https://github.com/dorny/paths-filter) でジョブレベル skip する設計です。ワークフローレベルの `paths:` だとチェックが「存在しない」状態になり required status checks でマージがブロックされますが、ジョブレベル skip は GitHub 上で pass 扱いになるためこの問題を回避できます。
+>
+> **Draft PR:** 全ワークフローは `types: [opened, synchronize, reopened, ready_for_review]` で Draft PR をスキップします。Draft から Ready に変更すると `ready_for_review` イベントで CI が起動します。
 
 ### Storybook ホスティング
 


### PR DESCRIPTION
## Summary
- 全ワークフロー名に絵文字プレフィックスを追加（✅📸🧪🟣🔶🏗️🧹）して視認性を向上
- Draft PR では CI をスキップし、Ready for review に変更された時点で CI を実行
- マージ後に required status checks を gh API で設定予定

## Draft PR の挙動
- `pull_request.types` に `ready_for_review` を追加
- `changes` ジョブ（または CI ジョブ）に `!github.event.pull_request.draft` チェックを追加
- Draft PR → 全ジョブ skip（pass 扱い）
- Ready for review → 通常どおり CI 実行

## Required Status Checks（マージ後に設定）
- ✅ Lint / Syncpack / Typecheck / Knip / Test / Build
- 📸 Storybook VRT
- 🧪 E2E Test Report
- 🟣 Deploy to Chromatic
- 🔶 Deploy to Cloudflare Pages
- 🏗️ Terraform Format / Validate / Lint
- 🏗️ Terraform Plan

## Test plan
- [ ] CI パス確認
- [ ] マージ後に required status checks を設定
- [ ] Draft PR で CI がスキップされることを確認
- [ ] Ready for review で CI が実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)