### PR TITLE
fix: ジョブ名の絵文字を全てユニークに変更

### DIFF
--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -97,7 +97,7 @@ jobs:
 
   # ── Plan + apply 漏れ検出（Secrets 必要） ──
   plan:
-    name: 🏗️ Terraform Plan
+    name: 📋 Terraform Plan
     needs: changes
     if: github.event_name == 'pull_request' && needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/storybook-chromatic-deploy.yml
+++ b/.github/workflows/storybook-chromatic-deploy.yml
@@ -16,7 +16,7 @@
 # 公式ドキュメント:
 #   https://www.chromatic.com/docs/github-actions/
 # ==============================================
-name: 🟣 Storybook Chromatic Deploy
+name: 🎨 Storybook Chromatic Deploy
 
 on:
   # main push 時: Chromatic へプロダクションデプロイ
@@ -55,7 +55,7 @@ jobs:
               - '.github/workflows/storybook-chromatic-deploy.yml'
 
   deploy:
-    name: 🟣 Deploy to Chromatic
+    name: 🎨 Deploy to Chromatic
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -106,7 +106,7 @@ jobs:
       # Job Summary にビルド結果の URL を表示
       - name: Add summary
         run: |
-          echo "## 🟣 Chromatic" >> $GITHUB_STEP_SUMMARY
+          echo "## 🎨 Chromatic" >> $GITHUB_STEP_SUMMARY
           echo "| Key | URL |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|-----|" >> $GITHUB_STEP_SUMMARY
           echo "| Storybook | ${{ steps.chromatic.outputs.storybookUrl }} |" >> $GITHUB_STEP_SUMMARY
@@ -120,7 +120,7 @@ jobs:
         with:
           header: chromatic-storybook
           message: |
-            ## 🟣 Chromatic Storybook Preview
+            ## 🎨 Chromatic Storybook Preview
 
             | Key | URL |
             |-----|-----|

--- a/.github/workflows/storybook-cloudflare-deploy.yml
+++ b/.github/workflows/storybook-cloudflare-deploy.yml
@@ -21,7 +21,7 @@
 #     bunx wrangler pages project create <project-name> --production-branch main
 #   Cloudflare Access: Zero Trust > Access > Applications で認証ポリシーを設定
 # ==============================================
-name: 🔶 Storybook Cloudflare Pages Deploy
+name: ☁️ Storybook Cloudflare Pages Deploy
 
 on:
   # main push 時: プロダクションデプロイ
@@ -60,7 +60,7 @@ jobs:
               - '.github/workflows/storybook-cloudflare-deploy.yml'
 
   deploy:
-    name: 🔶 Deploy to Cloudflare Pages
+    name: ☁️ Deploy to Cloudflare Pages
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -104,7 +104,7 @@ jobs:
       # Job Summary にデプロイ結果の URL を表示
       - name: Add summary
         run: |
-          echo "## 🔶 Cloudflare Pages" >> $GITHUB_STEP_SUMMARY
+          echo "## ☁️ Cloudflare Pages" >> $GITHUB_STEP_SUMMARY
           echo "| Key | URL |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|-----|" >> $GITHUB_STEP_SUMMARY
           echo "| Storybook | ${{ steps.deploy.outputs.deployment-url }} |" >> $GITHUB_STEP_SUMMARY
@@ -116,7 +116,7 @@ jobs:
         with:
           header: cloudflare-storybook
           message: |
-            ## 🔶 Cloudflare Pages Storybook Preview
+            ## ☁️ Cloudflare Pages Storybook Preview
 
             | Key | URL |
             |-----|-----|

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -186,7 +186,7 @@ jobs:
   # デプロイ（gh-pages への push のみ直列化）
   # ────────────────────────────────────────
   deploy:
-    name: "Deploy \U0001F4F8 Storybook VRT Report"
+    name: "🚀 Deploy Storybook VRT Report"
     needs: [changes, test]
     if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -245,7 +245,7 @@ jobs:
   # デプロイ（gh-pages への push のみ直列化）
   # ────────────────────────────────────────
   deploy:
-    name: "Deploy \U0001F9EA E2E Test Report"
+    name: "📊 Deploy E2E Test Report"
     needs: [changes, test]
     if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -268,8 +268,8 @@ PR 作成時（Ready for review）に GitHub Actions が自動実行されます
 - 🏗️ **Infra CI** (`infra-ci.yml`): 全 PR で起動し、`infra/` の変更時のみ Terraform Format / Validate / tflint を実行（変更なしの場合はジョブ skip = pass）
 - 📸 **Storybook VRT** (`storybook-vrt.yml`): 全 PR で起動し、`packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
 - 🧪 **E2E テスト** (`web-e2e.yml`): 全 PR で起動し、`apps/web/` または `packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
-- 🟣 **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
-- 🔶 **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
+- 🎨 **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
+- ☁️ **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
 - 🧹 **Cleanup GitHub Pages** (`github-pages-cleanup.yml`): PR クローズ時に gh-pages の容量をチェックし、800MB 超過時に古いレポートを削除
 
 > **Note:** paths フィルタ付きワークフロー（VRT, E2E, Chromatic, Cloudflare, Infra CI）は全 PR で起動し、[dorny/paths-filter](https://github.com/dorny/paths-filter) でジョブレベル skip する設計です。ワークフローレベルの `paths:` だとチェックが「存在しない」状態になり required status checks でマージがブロックされますが、ジョブレベル skip は GitHub 上で pass 扱いになるためこの問題を回避できます。


### PR DESCRIPTION
## Summary
- 絵文字がかぶっていたジョブ名を全てユニークに変更
- Chromatic / Cloudflare のアイコンをより直感的なものに変更

| ジョブ | 変更前 | 変更後 |
|---|---|---|
| Terraform Plan | 🏗️ | 📋 |
| Deploy VRT Report | 📸 | 🚀 |
| Deploy E2E Report | 🧪 | 📊 |
| Deploy to Chromatic | 🟣 | 🎨 |
| Deploy to Cloudflare | 🔶 | ☁️ |

### 最終的な絵文字一覧
- ✅ Lint / Syncpack / Typecheck / Knip / Test / Build
- 📸 Storybook VRT
- 🚀 Deploy Storybook VRT Report
- 🧪 E2E Test Report
- 📊 Deploy E2E Test Report
- 🎨 Deploy to Chromatic
- ☁️ Deploy to Cloudflare Pages
- 🏗️ Terraform Format / Validate / Lint
- 📋 Terraform Plan
- 🧹 Cleanup GitHub Pages

## Test plan
- [ ] CI パス確認
- [ ] マージ後に required status checks を新しい名前で再設定

🤖 Generated with [Claude Code](https://claude.com/claude-code)