### PR TITLE
refactor: actions-timeline ジョブ削除 + lefthook ジョブ名改善

### DIFF
--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -61,6 +61,8 @@ jobs:
       # セットアップ
       # ────────────────────────────────────────
 
+      - uses: Kesin11/actions-timeline@v3
+
       - uses: actions/checkout@v6
         with:
           # ベースライン生成で base branch を参照するため全履歴が必要
@@ -223,15 +225,3 @@ jobs:
             | Report | Link |
             |--------|------|
             | reg-cli | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/storybook-vrt/reg-report/report/ |
-
-  # ────────────────────────────────────────
-  # ワークフロー実行タイムライン可視化
-  # ────────────────────────────────────────
-  actions-timeline:
-    name: Actions Timeline
-    needs: [changes, test, deploy]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: Kesin11/actions-timeline@v3

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -56,6 +56,8 @@ jobs:
       # セットアップ
       # ────────────────────────────────────────
 
+      - uses: Kesin11/actions-timeline@v3
+
       - uses: actions/checkout@v6
         with:
           # ベースライン生成で base branch を参照するため全履歴が必要
@@ -289,15 +291,3 @@ jobs:
             | reg-cli | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/web-e2e/reg-report/report/ |
             | Playwright HTML | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/web-e2e/html-report/ |
             | Allure | https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/${{ env.REPORT_PREFIX }}/web-e2e/allure-report/ |
-
-  # ────────────────────────────────────────
-  # ワークフロー実行タイムライン可視化
-  # ────────────────────────────────────────
-  actions-timeline:
-    name: Actions Timeline
-    needs: [changes, test, deploy]
-    if: (github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true') && !cancelled()
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: Kesin11/actions-timeline@v3

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -18,12 +18,12 @@ output:
 # {1} = ブランチ切替フラグ（1: ブランチ切替、0: ファイルチェックアウト）
 post-checkout:
   jobs:
-    - name: bun-install
+    - name: sync-bun-deps
       run: |
         [ "{1}" != "1" ] && exit 0
         git diff HEAD@{1} HEAD --quiet -- bun.lock 2>/dev/null || bun install --frozen-lockfile
     # mise.toml に変更があればツールを自動インストール
-    - name: mise-install
+    - name: sync-mise-tools
       run: |
         [ "{1}" != "1" ] && exit 0
         git diff HEAD@{1} HEAD --quiet -- mise.toml 2>/dev/null || mise install
@@ -31,9 +31,9 @@ post-checkout:
 # マージ・プル時: bun.lock / mise.toml に変更があれば自動同期
 post-merge:
   jobs:
-    - name: bun-install
+    - name: sync-bun-deps
       run: git diff HEAD@{1} HEAD --quiet -- bun.lock 2>/dev/null || bun install --frozen-lockfile
-    - name: mise-install
+    - name: sync-mise-tools
       run: git diff HEAD@{1} HEAD --quiet -- mise.toml 2>/dev/null || mise install
 
 # コミット時: ステージされたファイルに対して実行


### PR DESCRIPTION
## Summary
- VRT/E2E ワークフローから独立した `actions-timeline` ジョブを削除し、`test` ジョブのステップに移動（PR チェック一覧の項目数を削減）
- lefthook の post-checkout/post-merge ジョブ名を実態に合わせて変更（`bun-install` → `sync-bun-deps`, `mise-install` → `sync-mise-tools`）

## Test plan
- [ ] VRT/E2E ワークフローが正常に動作すること
- [ ] actions-timeline がステップとして正しく記録されること
- [ ] lefthook の post-checkout/post-merge が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)