### PR TITLE
perf: CI 高速化 — prepare スキップ + Renovate Validator 条件実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,15 @@ jobs:
 
       # ── 静的解析 ──
       # ローカルでは renovate パッケージの WASM エラーにより実行不可のため CI でのみ検証
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            renovate:
+              - 'renovate.json5'
+
       - name: Renovate Config Validator
+        if: steps.changes.outputs.renovate == 'true'
         uses: suzuki-shunsuke/github-action-renovate-config-validator@v2.1.0
         with:
           config_file_path: renovate.json5

--- a/README.md
+++ b/README.md
@@ -65,12 +65,14 @@ curl https://mise.run | sh
 # ツールインストール
 mise install
 
-# パッケージインストール
+# パッケージインストール（lefthook + Playwright ブラウザも自動セットアップ）
 bun install
 
 # クリーンインストール + 全チェック実行（リント・型チェック・テスト・ビルド・VRT・E2E）
 bun run clean:setup
 ```
+
+> **Note:** `bun install` 時に `prepare` スクリプトで lefthook の Git hooks 登録と Playwright ブラウザのインストールが自動実行されます。CI 環境（`CI=true`）ではこれらをスキップし、必要なワークフローで個別にインストールしています。
 
 ## オンボーディング（新メンバー向け）
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "clean": "rm -rf bun.lock node_modules apps/*/node_modules packages/*/node_modules apps/*/.next packages/*/storybook-static dist coverage *.tsbuildinfo apps/*/.reg packages/*/.reg apps/*/allure-results apps/*/allure-report apps/*/allure-history.jsonl apps/*/playwright-report apps/*/test-results blob-report .oxc_cache **/__vis__/__diff_output__ **/__vis__/**/__diffs__ **/__vis__/**/__results__ **/__vis__/local .playwright-mcp",
     "clean:install": "bun run clean && bun install",
     "clean:setup": "bun run clean:install && bun run ci:full",
-    "prepare": "lefthook install && bunx playwright install --with-deps",
+    "prepare": "[ -n \"$CI\" ] || (lefthook install && bunx playwright install --with-deps)",
     "🪝": "========== Lefthook ==========",
     "lefthook:pre-commit": "lefthook run pre-commit --force",
     "lefthook:pre-push": "lefthook run pre-push --force"


### PR DESCRIPTION
## Summary
- `package.json` の `prepare` スクリプトに CI ガード（`[ -n "$CI" ]`）を追加し、CI 環境では `lefthook install` と `bunx playwright install --with-deps` をスキップ
- `dorny/paths-filter@v3` で `renovate.json5` が変更された場合のみ Renovate Config Validator を実行
- README に `prepare` スクリプトの挙動について注記を追加

## Review
- `prepare` で実行される lefthook（git hooks）と Playwright ブラウザは ci.yml のジョブでは不要（E2E/VRT は別ワークフローで個別にインストール済み）
- `dorny/paths-filter` は他のワークフローでも同じパターンで使用済み
- bun install の約45秒のうち Playwright ダウンロード分が短縮される見込み
- Renovate Validator は renovate.json5 未変更時に36秒スキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)