### PR TITLE
fix: actions/setup-node を v6 に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Setup Node.js for Renovate Validator
         if: steps.changes.outputs.renovate == 'true'
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
           node-version: lts/*
 


### PR DESCRIPTION
## Summary

- CI の Renovate Config Validator 用 `actions/setup-node` を v4 → v6 に更新
- PR #47 でマージ漏れした修正

## Test plan

- [ ] CI の Renovate Config Validator ステップが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)