### PR TITLE
feat: Renovate PR を main 更新時に常にリベースする設定を追加

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -89,6 +89,11 @@
   commitMessageAction: "[Renovate] update",
   commitMessageTopic: "{{depName}}",
 
+  // main が更新されたら Renovate PR を常にリベースして追従する
+  // デフォルト（auto）ではコンフリクト時のみリベースするため、
+  // PR が "out-of-date with base branch" のまま放置されることがある
+  rebaseWhen: "behind-base-branch",
+
   // ブランチ設定
   branchPrefix: "feature/renovate-",
   baseBranchPatterns: ["$default"],


### PR DESCRIPTION
## Summary

- `rebaseWhen: "behind-base-branch"` を追加
- main が更新されると Renovate PR が自動でリベースされ、「out-of-date with base branch」状態を防ぐ
- デフォルト（`auto`）ではコンフリクト時のみリベースだったため、マージ時に手動で Update branch が必要だった

## Test plan

- [ ] main にマージ後、既存の Renovate PR がリベースされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)