### PR TITLE
fix: Renovate のスケジュール制限を撤廃

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -72,12 +72,6 @@
     },
   ],
 
-  // スケジュール: 平日 10:00-17:59 JST
-  // cron 形式 — 分(*) 時(10-17) 日(*) 月(*) 曜日(1-5=月-金)
-  // ※ @breejs/later テキスト構文は非推奨、cron 形式が推奨
-  //    https://docs.renovatebot.com/key-concepts/scheduling/#deprecated-breejslater-syntax
-  schedule: ["* 10-17 * * 1-5"],
-
   // PR 設定（時間あたり制限なし、同時最大10件）
   prHourlyLimit: 0,
   prConcurrentLimit: 10,


### PR DESCRIPTION
## Summary

- 平日 10:00-17:59 JST のスケジュール制限を削除
- Renovate が24時間365日動作し、更新を即時検知・PR作成するようにした

## Test plan

- [ ] Renovate が時間帯に関係なく PR を作成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)