### PR TITLE
fix: peaceiris/actions-gh-pages → JamesIves/github-pages-deploy-action に移行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
 
       # ── 静的解析 ──
       # ローカルでは renovate パッケージの WASM エラーにより実行不可のため CI でのみ検証
+      #
+      # AurorNZ/paths-filter: dorny/paths-filter のフォーク。
+      # 本家は 2024-03 以降メンテナンス停滞し Node20 非推奨化（2026-04）への
+      # 対応が見込めないため、Node24 対応済み・API 完全互換の AurorNZ 版に移行。
       - uses: AurorNZ/paths-filter@c9dd42e99db87803313ff6f4b1150cc9f6c836af # v5
         id: changes
         with:

--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -209,12 +209,15 @@ jobs:
           name: storybook-vrt-deploy-payload
           path: _gh-pages-staging/
 
+      # peaceiris/actions-gh-pages は 2024-04 以降メンテナンス停滞し
+      # Node24 対応が見込めないため、Node24 対応済みの JamesIves 版に移行。
+      # 同じ gh-pages ブランチ方式で API 互換性が高い。
       - name: Deploy reports to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _gh-pages-staging
-          keep_files: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          folder: _gh-pages-staging
+          clean: false
 
       # sticky-pull-request-comment: 同じ header のコメントがあれば更新、なければ新規作成
       - name: Comment PR with report links

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -229,12 +229,15 @@ jobs:
           name: web-e2e-deploy-payload
           path: _gh-pages-staging/
 
+      # peaceiris/actions-gh-pages は 2024-04 以降メンテナンス停滞し
+      # Node24 対応が見込めないため、Node24 対応済みの JamesIves 版に移行。
+      # 同じ gh-pages ブランチ方式で API 互換性が高い。
       - name: Deploy reports to GitHub Pages
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _gh-pages-staging
-          keep_files: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          folder: _gh-pages-staging
+          clean: false
 
       # ────────────────────────────────────────
       # PR コメント


### PR DESCRIPTION
## Summary
- peaceiris/actions-gh-pages（2024-04 以降メンテナンス停滞、Node24 未対応）を JamesIves/github-pages-deploy-action v4（Node24 対応済み）に移行
- 同じ gh-pages ブランチ方式のため、オプション名の読み替えのみで移行完了
- ci.yml に paths-filter（AurorNZ）の採用理由コメントを追加

## Test plan
- [ ] CI が通ること
- [ ] GH Pages へのデプロイが正常に動作すること（storybook-vrt / web-e2e の deploy ジョブ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)