### PR TITLE
fix: GH Pages deploy に actions/checkout を追加

### DIFF
--- a/.github/workflows/storybook-vrt.yml
+++ b/.github/workflows/storybook-vrt.yml
@@ -203,6 +203,8 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Download deploy payload
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -223,6 +223,8 @@ jobs:
       group: gh-pages-deploy
       cancel-in-progress: false
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
       - name: Download deploy payload
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8
         with:


### PR DESCRIPTION
## Summary
- JamesIves/github-pages-deploy-action は git リポジトリのチェックアウトが前提（peaceiris 版は不要だった）
- deploy ジョブに `actions/checkout` を追加して `fatal: not in a git directory` エラーを修正
- #57 で deploy ジョブが失敗したままマージされた修正

## Test plan
- [ ] CI の deploy ジョブ（🚀 Deploy Storybook VRT Report / 📊 Deploy E2E Test Report）が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)