### PR TITLE
fix: clsx の Renovate abandoned 警告を抑制

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -70,6 +70,13 @@
       matchUpdateTypes: ["pin"],
       enabled: false,
     },
+
+    // clsx は機能的に完成しており、abandoned ではなくメンテナンス不要な状態
+    // Renovate の abandoned 警告を抑制する
+    {
+      matchPackageNames: ["clsx"],
+      abandonmentThreshold: null,
+    },
   ],
 
   // PR 設定（時間あたり制限なし、同時最大10件）


### PR DESCRIPTION
## Summary
- clsx に対して `abandonmentThreshold: null` を設定し、Renovate ダッシュボードの「Abandoned Dependencies」セクションから除外
- clsx は週間 5,600 万 DL の安定ライブラリで、機能的に完成しておりメンテナンス不要な状態。リリースが止まっているだけで abandoned ではない

ref: https://github.com/sugurutakahashi-1234/storybook-vrt-sample/issues/32

## Test plan
- [ ] Renovate の次回実行後、ダッシュボードの Abandoned Dependencies セクションから clsx が消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)