### PR TITLE
feat: Sentry のクライアントサイドノイズフィルタを追加

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -20,4 +20,30 @@ Sentry.init({
   // 全リクエストを記録すると課金が膨らむため、本番では 10% に抑える
   // 開発中は全件記録して動作確認しやすくする
   tracesSampleRate: process.env.NODE_ENV === "production" ? 0.1 : 1,
+
+  // ── ノイズ除去 ──
+  // ユーザー操作に影響しない既知のブラウザエラーを無視して、無料枠を節約する
+  ignoreErrors: [
+    // ResizeObserver のループ超過（ブラウザ仕様上の無害な警告）
+    "ResizeObserver loop limit exceeded",
+    "ResizeObserver loop completed with undelivered notifications",
+    // ネットワーク切断やタイムアウトで発生する一時的なエラー
+    /^Load failed$/,
+    /^Failed to fetch$/,
+    /^NetworkError/,
+    // Next.js のクライアントナビゲーション中断（ユーザーが素早くページ遷移した場合）
+    "NEXT_NOT_FOUND",
+    // 非 Error オブジェクトが throw された場合のフォールバック（有用な情報がない）
+    /^Non-Error exception captured/,
+  ],
+
+  // ブラウザ拡張やサードパーティスクリプトのエラーを送信しない
+  // 自分のアプリ由来でないエラーは対処不能なので除外する
+  denyUrls: [
+    /extensions\//i,
+    /^chrome:\/\//i,
+    /^chrome-extension:\/\//i,
+    /^moz-extension:\/\//i,
+    /^safari-extension:\/\//i,
+  ],
 });


### PR DESCRIPTION
## Summary

- ブラウザ拡張・ResizeObserver・ネットワーク断等の無害なエラーを `ignoreErrors` / `denyUrls` で除外
- 無料枠（5,000 イベント/月）のイベント消費を抑える

## 変更内容

`apps/web/instrumentation-client.ts` に以下を追加：

- **ignoreErrors**: ResizeObserver ループ超過、ネットワークエラー、Next.js ナビゲーション中断、Non-Error exception
- **denyUrls**: Chrome / Firefox / Safari のブラウザ拡張 URL

サーバーサイド（`sentry.server.config.ts` / `sentry.edge.config.ts`）にはブラウザ拡張由来のエラーは到達しないため、フィルタは不要。

## Test plan

- [x] `bun run build` が成功すること
- [x] `bun run lint` がクリーンであること

🤖 Generated with [Claude Code](https://claude.com/claude-code)