### PR TITLE
feat: dotenvx 復号キーの一元化 + Slack MCP サーバー追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@
 #
 # 必要な設定:
 #   Secrets:
-#     DOTENV_PRIVATE_KEY_WEB — apps/web/.env.keys の DOTENV_PRIVATE_KEY
+#     DOTENV_PRIVATE_KEY — 全 .env ファイル共通の復号キー
 #       dotenvx で暗号化された .env を復号し、Next.js の環境変数（NEXT_PUBLIC_SENTRY_DSN 等）を注入する
 #       ※ 個別の Secrets 登録は不要。.env に変数を追加すれば CI にも自動反映される
 # ==============================================
@@ -68,5 +68,4 @@ jobs:
         run: bun run --parallel --no-exit-on-error lint syncpack typecheck knip test build
         env:
           # dotenvx が apps/web/.env を復号するために必要（Sentry DSN 等）
-          # 値は apps/web/.env.keys の DOTENV_PRIVATE_KEY を GitHub Secrets に登録する
-          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY_WEB }}
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}

--- a/.github/workflows/infra-ci.yml
+++ b/.github/workflows/infra-ci.yml
@@ -20,11 +20,9 @@
 #
 # 必要な設定:
 #   Secrets:
-#     DOTENV_PRIVATE_KEY_INFRA — infra/cloudflare-access/.env.keys の DOTENV_PRIVATE_KEY
-#       dotenvx で暗号化された .env を復号し、全環境変数（CLOUDFLARE_API_TOKEN, TF_VAR_* 等）を注入する
+#     DOTENV_PRIVATE_KEY — 全 .env ファイル共通の復号キー
+#       dotenvx で暗号化された .env を復号し、環境変数（CLOUDFLARE_API_TOKEN, TF_VAR_*, SENTRY_AUTH_TOKEN 等）を注入する
 #       ※ 個別の Secrets 登録は不要。.env に変数を追加すれば CI にも自動反映される
-#     DOTENV_PRIVATE_KEY_SENTRY — infra/sentry/.env.keys の DOTENV_PRIVATE_KEY
-#       dotenvx で暗号化された .env を復号し、SENTRY_AUTH_TOKEN を注入する
 #     TF_API_TOKEN — HCP Terraform (Terraform Cloud) の API トークン
 #       state の読み書きに必要。Organization Settings > API Tokens で Team Token を作成
 #
@@ -130,9 +128,7 @@ jobs:
             dotenvx get -f "$env_file" --format shell | tr ' ' '\n' >> "$GITHUB_ENV"
           done
         env:
-          # dotenvx は DOTENV_PRIVATE_KEY をカンマ区切りで複数キーを受け付ける
-          # infra/ 配下に新しいモジュールを追加したら、そのキーもここに追加する
-          DOTENV_PRIVATE_KEY: "${{ secrets.DOTENV_PRIVATE_KEY_INFRA }},${{ secrets.DOTENV_PRIVATE_KEY_SENTRY }}"
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
 
       # infra/*/ を走査して init + plan を実行
       # tfcmt が plan 結果を整形して PR コメントに自動投稿する

--- a/.github/workflows/storybook-cloudflare-deploy.yml
+++ b/.github/workflows/storybook-cloudflare-deploy.yml
@@ -14,9 +14,6 @@
 #     CLOUDFLARE_API_TOKEN    — Cloudflare API Token「GitHub Actions - Cloudflare Pages」
 #       権限: Cloudflare Pages: Edit
 #       ※ Terraform 用トークン（infra/cloudflare-access/.env で管理）とは別トークン
-#   Variables:
-#     CLOUDFLARE_ACCOUNT_ID   — Cloudflare ダッシュボード > Workers & Pages > Account ID（`bunx wrangler whoami` でも確認可）
-#     CF_PAGES_PROJECT_NAME   — Cloudflare Pages プロジェクト名（`<project-name>.pages.dev` のサブドメインになる）
 #   初回セットアップ:
 #     bunx wrangler pages project create <project-name> --production-branch main
 #   Cloudflare Access: Zero Trust > Access > Applications で認証ポリシーを設定
@@ -95,8 +92,10 @@ jobs:
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy packages/ui/storybook-static --project-name=${{ vars.CF_PAGES_PROJECT_NAME }} --branch=${{ github.head_ref || 'main' }}
+          # Account ID: Cloudflare ダッシュボード > Workers & Pages > Account ID（`bunx wrangler whoami` でも確認可）
+          accountId: 95d6c4c8536abbe739beadf65c380ae4
+          # project-name: Cloudflare Pages プロジェクト名（`<project-name>.pages.dev` のサブドメインになる）
+          command: pages deploy packages/ui/storybook-static --project-name=storybook-vrt-sample --branch=${{ github.head_ref || 'main' }}
 
       # ────────────────────────────────────────
       # レポート
@@ -109,7 +108,7 @@ jobs:
           echo "| Key | URL |" >> $GITHUB_STEP_SUMMARY
           echo "|-----|-----|" >> $GITHUB_STEP_SUMMARY
           echo "| Storybook | ${{ steps.deploy.outputs.deployment-url }} |" >> $GITHUB_STEP_SUMMARY
-          echo "| Dashboard | https://dash.cloudflare.com/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/pages/view/${{ vars.CF_PAGES_PROJECT_NAME }}/${{ steps.deploy.outputs.pages-deployment-id }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Dashboard | https://dash.cloudflare.com/95d6c4c8536abbe739beadf65c380ae4/pages/view/storybook-vrt-sample/${{ steps.deploy.outputs.pages-deployment-id }} |" >> $GITHUB_STEP_SUMMARY
 
       # sticky-pull-request-comment: 同じ header のコメントがあれば更新、なければ新規作成
       - name: Comment PR with Storybook link
@@ -123,4 +122,4 @@ jobs:
             | Key | URL |
             |-----|-----|
             | Storybook | ${{ steps.deploy.outputs.deployment-url }} |
-            | Dashboard | https://dash.cloudflare.com/${{ vars.CLOUDFLARE_ACCOUNT_ID }}/pages/view/${{ vars.CF_PAGES_PROJECT_NAME }}/${{ steps.deploy.outputs.pages-deployment-id }} |
+            | Dashboard | https://dash.cloudflare.com/95d6c4c8536abbe739beadf65c380ae4/pages/view/storybook-vrt-sample/${{ steps.deploy.outputs.pages-deployment-id }} |

--- a/.github/workflows/web-e2e.yml
+++ b/.github/workflows/web-e2e.yml
@@ -8,7 +8,7 @@
 #
 # 必要な設定:
 #   Secrets:
-#     DOTENV_PRIVATE_KEY_WEB — apps/web/.env.keys の DOTENV_PRIVATE_KEY
+#     DOTENV_PRIVATE_KEY — 全 .env ファイル共通の復号キー
 #       dotenvx で暗号化された .env を復号し、Next.js の環境変数（NEXT_PUBLIC_SENTRY_DSN 等）を注入する
 name: 🧪 E2E Tests
 
@@ -111,7 +111,7 @@ jobs:
       - name: Generate baselines from base branch
         if: github.event_name == 'pull_request'
         env:
-          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY_WEB }}
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
         run: |
           BASE_REF="${{ github.event.pull_request.base.ref }}"
           git worktree add /tmp/baseline "origin/${BASE_REF}" --detach
@@ -130,7 +130,7 @@ jobs:
         run: bun run build
         working-directory: apps/web
         env:
-          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY_WEB }}
+          DOTENV_PRIVATE_KEY: ${{ secrets.DOTENV_PRIVATE_KEY }}
 
       # Playwright テスト実行（ページ遷移・レスポンシブ検証）
       - name: Run Playwright tests

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ coverage/
 .env
 !infra/**/.env
 !apps/web/.env
+!mcp/.env
 .env.local
 .env.*.local
 .env.sentry-build-plugin

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,21 @@
     "storybook-mcp": {
       "type": "http",
       "url": "http://localhost:6006/mcp"
+    },
+    "slack": {
+      "command": "dotenvx",
+      "args": [
+        "run",
+        "-f",
+        "mcp/.env",
+        "--",
+        "npx",
+        "-y",
+        "@modelcontextprotocol/server-slack"
+      ],
+      "env": {
+        "SLACK_TEAM_ID": "T08LT7S9PBN"
+      }
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ storybook-vrt-sample/
 │   └── web/                  # Next.js アプリ + E2E テスト
 ├── packages/
 │   └── ui/                   # 共有 UI コンポーネント + Storybook + VRT
+├── mcp/                      # MCP サーバーのシークレット管理
 ├── infra/
 │   ├── cloudflare-access/    # Cloudflare Access (Zero Trust) の Terraform 管理
 │   └── sentry/               # Sentry エラー監視の Terraform 管理
@@ -90,17 +91,15 @@ bun run clean:setup
    ```
    ブラウザが開くので、Terraform Cloud で認証する。トークンが `~/.terraform.d/credentials.tfrc.json` に保存される。
 4. **`.env.keys` の取得**
-   - 以下のファイルをパスワードマネージャーから取得して配置する
-     - `apps/web/.env.keys` — Next.js アプリの環境変数復号キー（Sentry DSN 等）
-     - `infra/cloudflare-access/.env.keys` — Cloudflare Access Terraform の環境変数復号キー
-     - `infra/sentry/.env.keys` — Sentry Terraform の環境変数復号キー
-   - これらのファイルには dotenvx の復号キー（`DOTENV_PRIVATE_KEY`）が含まれる
+   - ルートの `.env.keys` を管理者から取得して配置する（中身は `DOTENV_PRIVATE_KEY=xxx` の1行のみ）
 5. **動作確認**
 
    ```bash
+   # MCP サーバーの環境変数が復号できることを確認
+   cd mcp && dotenvx get | jq .
+
    # Next.js アプリの環境変数が復号できることを確認
-   cd apps/web
-   dotenvx get | jq .
+   cd apps/web && dotenvx get | jq .
 
    # Terraform の環境変数が復号できることを確認
    cd infra/cloudflare-access
@@ -112,7 +111,7 @@ bun run clean:setup
    dotenvx run -- terraform plan
    ```
 
-   Next.js 側は変数が表示されれば OK。Terraform 側は `No changes.` と表示されれば正常にセットアップ完了。
+   MCP・Next.js 側は変数が表示されれば OK。Terraform 側は `No changes.` と表示されれば正常にセットアップ完了。
 
 ## 開発ワークフロー
 
@@ -395,7 +394,7 @@ dotenvx run -- terraform apply
 #### シークレット管理（dotenvx）
 
 環境変数は `infra/cloudflare-access/.env` に dotenvx で暗号化して保存しています。
-復号には `.env.keys` ファイルが必要です（パスワードマネージャー等で共有）。
+復号にはルートの `.env.keys` が必要です（管理者から安全な方法で共有）。
 
 ```bash
 cd infra/cloudflare-access
@@ -497,26 +496,25 @@ dotenvx run -- terraform apply
 
 ### GitHub Secrets（Settings > Secrets and variables > Actions）
 
-| Secret                      | 用途                           | 使用ワークフロー                  | 取得先                                                        |
-| --------------------------- | ------------------------------ | --------------------------------- | ------------------------------------------------------------- |
-| `CHROMATIC_PROJECT_TOKEN`   | Chromatic デプロイ             | `storybook-chromatic-deploy.yml`  | [Chromatic](https://www.chromatic.com/) > Project > Configure |
-| `CLOUDFLARE_API_TOKEN`      | Cloudflare Pages デプロイ      | `storybook-cloudflare-deploy.yml` | Cloudflare > My Profile > API Tokens（権限: Pages Edit）      |
-| `DOTENV_PRIVATE_KEY_INFRA`  | Cloudflare Access 用 .env 復号 | `infra-ci.yml`                    | `infra/cloudflare-access/.env.keys` の `DOTENV_PRIVATE_KEY`   |
-| `DOTENV_PRIVATE_KEY_SENTRY` | Sentry 用 .env 復号            | `infra-ci.yml`                    | `infra/sentry/.env.keys` の `DOTENV_PRIVATE_KEY`              |
-| `DOTENV_PRIVATE_KEY_WEB`    | Next.js 用 .env 復号           | `ci.yml`, `web-e2e.yml`           | `apps/web/.env.keys` の `DOTENV_PRIVATE_KEY`                  |
-| `TF_API_TOKEN`              | Terraform Cloud API トークン   | `infra-ci.yml`                    | Terraform Cloud > Organization Settings > Teams > Team Token  |
-
-### GitHub Variables（Settings > Secrets and variables > Actions）
-
-| Variable                | 用途                            | 使用ワークフロー                  |
-| ----------------------- | ------------------------------- | --------------------------------- |
-| `CLOUDFLARE_ACCOUNT_ID` | Cloudflare アカウント識別       | `storybook-cloudflare-deploy.yml` |
-| `CF_PAGES_PROJECT_NAME` | Cloudflare Pages プロジェクト名 | `storybook-cloudflare-deploy.yml` |
+| Secret                    | 用途                           | 使用ワークフロー                        | 取得先                                                        |
+| ------------------------- | ------------------------------ | --------------------------------------- | ------------------------------------------------------------- |
+| `CHROMATIC_PROJECT_TOKEN` | Chromatic デプロイ             | `storybook-chromatic-deploy.yml`        | [Chromatic](https://www.chromatic.com/) > Project > Configure |
+| `CLOUDFLARE_API_TOKEN`    | Cloudflare Pages デプロイ      | `storybook-cloudflare-deploy.yml`       | Cloudflare > My Profile > API Tokens（権限: Pages Edit）      |
+| `DOTENV_PRIVATE_KEY`      | 全 .env ファイル共通の復号キー | `ci.yml`, `web-e2e.yml`, `infra-ci.yml` | ルートの `.env.keys` の `DOTENV_PRIVATE_KEY`                  |
+| `TF_API_TOKEN`            | Terraform Cloud API トークン   | `infra-ci.yml`                          | Terraform Cloud > Organization Settings > Teams > Team Token  |
 
 ### dotenvx 暗号化
 
 環境変数を dotenvx で暗号化してリポジトリにコミットしています。
-復号には各ディレクトリの `.env.keys` が必要です（パスワードマネージャー等で共有）。
+復号にはルートの `.env.keys` が必要です（管理者から安全な方法で共有）。
+`mise.toml` の `[env] _.file` で `.env.keys` を自動読み込みし、`DOTENV_PRIVATE_KEY` 環境変数をセットします。
+これにより dotenvx コマンドは追加オプションなしで復号できます。
+
+**新しい暗号化環境を追加する手順:**
+
+1. 新ディレクトリで `.env` を作成
+2. `dotenvx encrypt -fk ../../.env.keys` で暗号化（ルートの `.env.keys` にキーが追加される）
+3. `.gitignore` に `!<dir>/.env` を追加（暗号化済みファイルをコミットするため）
 
 #### `apps/web/.env`（Next.js アプリ）
 
@@ -554,5 +552,24 @@ dotenvx get | jq .
 | 変数                | 用途                      | 取得先                                                                                                                                 |
 | ------------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
 | `SENTRY_AUTH_TOKEN` | Sentry Terraform Provider | [Sentry Auth Tokens](https://suguru-takahashi.sentry.io/settings/auth-tokens/)（権限: project:write, organization:read, alerts:write） |
+
+#### `mcp/.env`（MCP サーバー）
+
+| 変数              | 用途                  | 取得先                                                                                                                                           |
+| ----------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `SLACK_BOT_TOKEN` | Slack MCP Server 認証 | [Slack API](https://api.slack.com/apps) > Bot User OAuth Token（権限: channels:history, channels:read, chat:write, reactions:write, users:read） |
+
+`.mcp.json` の Slack MCP サーバーは `dotenvx run -f mcp/.env --` でラップされており、起動時に `mcp/.env` を自動復号してトークンを注入します。
+
+```bash
+cd mcp
+
+# 復号された全変数を確認
+dotenvx get | jq .
+
+# 新しい変数を追加する場合
+# 1. .env に平文で追加
+# 2. dotenvx encrypt で暗号化
+```
 
 各ワークフローのヘッダーコメントにも必要な Secrets/Variables の説明があります。

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -2,9 +2,9 @@
 #/            public-key encryption for .env files          /
 #/       [how it works](https://dotenvx.com/encryption)     /
 #/----------------------------------------------------------/
-DOTENV_PUBLIC_KEY="02271fae5f16c01beebf361ff9509eaa5e3d573d94b58e110d2485bf13d44f4df0"
+DOTENV_PUBLIC_KEY="03f83506aef1975a2728c7ad262c82a3e828be490a0a51ff14e3210d90fc91d578" # ../../.env.keys
 
 # .env
 # Sentry DSN（エラー監視の送信先）
 # 取得先: https://suguru-takahashi.sentry.io/settings/projects/storybook-vrt-sample/keys/
-NEXT_PUBLIC_SENTRY_DSN=encrypted:BA/KcLxZPMADrh0vGOmtra9E4Id7l39QNEJ6Dy0MlHbNTQ+f2QBnis4jQho9DleMn482VMRDV6x9ZZODfoIN7ZXzom92V1GqPn8n7JBWWZdFQpArvFlwdu93KzuYLt1CEbgdEeuer4XOU+bm79FHA4vjNxQFYOw4mib+OitaBgHgqalqejpBD5ZUH31+/EPs5GR/H1012fjAK40+eAIg8ZOOBR0CjFLbIaNJLo9e+Cqgcla6+xarMfROB2PV0Lq+
+NEXT_PUBLIC_SENTRY_DSN=encrypted:BN2ycxQOKIzZZ2LgYSkLJRKQ+em+q+XGzsIi3QKwmcjDPqbNcLlOhpsnMjPwFRq/kz8dELhxWbfFx/fpH1iRO7HmVtIOFmGvkfwsHw2E64oL9XUSvf8cEFJ378121POHNEfvkrD5EjLQgfJiMXiDZDwC3Ju2oFxif5v6bW7ZiMMn8Ib/z6UgKudxHR6K4cjvauTZ6JAVhervx5fUyBfchXIf6JI3yTmYRQNS4C9hh/D/qe328dGx3QoIo9TtXJZV

--- a/infra/cloudflare-access/.env
+++ b/infra/cloudflare-access/.env
@@ -2,12 +2,13 @@
 #/            public-key encryption for .env files          /
 #/       [how it works](https://dotenvx.com/encryption)     /
 #/----------------------------------------------------------/
-DOTENV_PUBLIC_KEY="0385be8e359856b19eb48508442a0ed1500a96117dd090fab0a0d7c49195fc031e"
+DOTENV_PUBLIC_KEY="03f83506aef1975a2728c7ad262c82a3e828be490a0a51ff14e3210d90fc91d578" # ../../.env.keys
 
+# .env
 # Cloudflare Access 用の環境変数（dotenvx で暗号化済み）
 #
-# セットアップ手順（infra/cloudflare-access/ で実行）:
-#   1. .env.keys をパスワードマネージャー等からコピーして配置
+# セットアップ手順:
+#   1. ルートの .env.keys を管理者から取得して配置
 #   2. dotenvx run -- terraform plan で動作確認
 #
 # 確認コマンド:
@@ -21,17 +22,17 @@ DOTENV_PUBLIC_KEY="0385be8e359856b19eb48508442a0ed1500a96117dd090fab0a0d7c49195f
 # Cloudflare provider 認証（API Token）
 # 取得先: Cloudflare ダッシュボード > My Profile > API Tokens
 #         権限: Access: Organizations/Apps/Policies/Identity Providers Edit
-CLOUDFLARE_API_TOKEN=encrypted:BJZmJ/r3N/ToZQGpuM8eAu4TtbmaRh9/lWd1I+PG2eWxuzRN3tKWFwEzSNCVmD55NjFui00i/MmfrtwuUtAE3iXovhMjS85cLR0FwcytJy6pkKRejelf1uGVVX010O8BL512TJEH1c1S2i4GFS6TyefczG/Q6UrgGD1hjtVMDO03VLDQVnp7hek=
+CLOUDFLARE_API_TOKEN=encrypted:BOvexvlGn3hNYziFJCAPS7MmfofN8rOGSdH+6tEHXrb4NwNNVxTgRwf60pnftH5sKBPOxoOkasCP52wpK53PWteDT1B3UYaXTBSynLmyKIHKJ7FR0D+eU7ZNwMhGXndSbxBDlZJSoPZetW/NFNlnpteN8fCj4Qo1UmW99AyIkAY2RRL04W3jr08=
 
 # GitHub OAuth App（Cloudflare Access の Identity Provider 用）
 # 取得先: https://github.com/settings/developers > OAuth Apps
 #         作成手順は main.tf のヘッダーコメントを参照
-TF_VAR_github_oauth_client_id=encrypted:BN90c+C9o/zdkYFHDBZ46UcZ+bBm2h9FlckcIvGYjhFbtF0ZFt/BrSeQxpTUBTsUToGTZUfZkG7KCr+kVvuWRJnEHwD+QUSQzw7Z1mDm8ZlST4CBf/8ZCzkxHKZ8r4e4+gA2tB19QrtBvn9DSVnX59SraPt8
-TF_VAR_github_oauth_client_secret=encrypted:BOScvRXZNjY+KBujOrFGLyjiIS2vU7K11++tnlXmWRnHAgyvGfVKk6J262Fc4KN+nx3LmxvVgbSY+XTlYg9D0VOs6Ek7xwQElQOZjIAfwew0O5mhgf67jbAmUHi2W6nbtlFHKD7VXuYAH6tHlFqKFXctBu3BZ42JGL2YS6dEt6O2LcDI6ekJb3A=
+TF_VAR_github_oauth_client_id=encrypted:BH1a4ArcKmibHvSCnHlSGOJSL/JXeFN7tj7stIwMdRyJd+lDw3HwVxXkSAatng3gWPMIiIWiGQNz/1U93i8fcFmG9y5mAecAqvJiXbL9PdPxf7tbANMdabaQVzV9eonhtNsHq7oKZCY9CXc/12e0RJ8PtfCQ
+TF_VAR_github_oauth_client_secret=encrypted:BGb1mDXc6m/xYuEzjZAdz/hQEwb9hIamo5riV+VAZnKTKVA0HctPvgqvkNoH8VfBMpYk1SGOdYfXjm9DFVqMpJvfHmxhA9audcHtwVkzp884y5X+G4N1xZtw7lld1JKmqU96BB3z6y+0O2weP+Pw9ZrW2qbtsnL9EJuFQ0ixK05Un8UmUgOFNTo=
 
 # Google OAuth クライアント（Cloudflare Access の Identity Provider 用）
 # 取得先: Google Cloud Console > Google Auth Platform > クライアント
 #         プロジェクト: storybook-vrt-sample
 #         作成手順は main.tf のヘッダーコメントを参照
-TF_VAR_google_oauth_client_id=encrypted:BCn66s+RVFWLJEx8jEeVPivtXGPiezVM71kewcfVG9J9R8mcnxLpZanekblvM4WzNsxr12YpdpIhXBSfuznO+mEcwHgcs6kwaAfvC4fNkx04BR6ShiolxDJnY2kUd5isVtc2xDLhYPHffQHy35MgGiShaT+sOssfZk7QD76ocuvgc3HizZKVkoJgk8k/tg+6Gg65KmkO/A4mEfmei1eyCXtyVoi1OJv7Mg==
-TF_VAR_google_oauth_client_secret=encrypted:BACIulvg2OdSLzKwEA3YJfg6wy1EATbVH/jQS2HygrPTUKAtrXSL05lh2fiPN2fwZYPlt/RVYMudqVPR4blR6CHmX/VC2YN7fi77aTCiwVnfdO3egIaRXTR+WLs19m1TtkAy8KboREYrtGsTZLiQVW29wsDJ0PIQxFJTG1ymjWiveQ27
+TF_VAR_google_oauth_client_id=encrypted:BLR9kQdarrER+hqjX1SarM6RslOn5NdJmJ3JNpaOCSciA/Ru5IZayeqcm71d/84HKbinVxl7Mk5mQDWjRMJCiWIPDUbbAUBJK4xG//dak08296uDCAyaoYj+DENaeH31/fSXXvQFhDfIuu51IPebUohj3+lU+yxlHh1TvBZ0JWr1GmL8+76Sqk4XYrHDhZoXxSLvQBWt4wiu6Hp+8X+j1oXK7N7cuJ1Iog==
+TF_VAR_google_oauth_client_secret=encrypted:BHu+JSzhF/QIPEbhjyWeXgQRtytFFUEwmonnSR7zoBB/vEzpeNXUM+UXx78+ZUL0p3TiAZk4ruVm1BVgyTxChLJpxQSTSHWlbbsL1Wi9y/QsqeJJ/NGZMpu+WMCdMr0urNjCvsT9NVcwh5WrlfPFPLbl6QdTa4KPwSCss0dvF8QSylhg

--- a/infra/sentry/.env
+++ b/infra/sentry/.env
@@ -2,12 +2,13 @@
 #/            public-key encryption for .env files          /
 #/       [how it works](https://dotenvx.com/encryption)     /
 #/----------------------------------------------------------/
-DOTENV_PUBLIC_KEY="025356ab1012698fd942f19e287fd697ad439f465fd6dc3e9c15058220b115ac76"
+DOTENV_PUBLIC_KEY="03f83506aef1975a2728c7ad262c82a3e828be490a0a51ff14e3210d90fc91d578" # ../../.env.keys
 
+# .env
 # Sentry Terraform Provider 用の環境変数（dotenvx で暗号化済み）
 #
-# セットアップ手順（infra/sentry/ で実行）:
-#   1. .env.keys をパスワードマネージャー等からコピーして配置
+# セットアップ手順:
+#   1. ルートの .env.keys を管理者から取得して配置
 #   2. dotenvx run -- terraform plan で動作確認
 #
 # 確認コマンド:
@@ -21,4 +22,4 @@ DOTENV_PUBLIC_KEY="025356ab1012698fd942f19e287fd697ad439f465fd6dc3e9c15058220b11
 # Sentry provider 認証（Personal Auth Token）
 # 取得先: https://suguru-takahashi.sentry.io/settings/auth-tokens/
 #         権限: project:write, organization:read, alerts:write
-SENTRY_AUTH_TOKEN=encrypted:BLCeafJwQWWWRw0cfIr70D5tdlorZioFO47+UOSr108kZWyRp9sO2tf7W1Yl3i6CsFtjolzUHKfvkLX/WjrUKhGFpJRlSdLzTMgqfGT45wg+1xeu2/5POvVYN3D9kWPeX18LaipAg67VRZUQhZ9H2pF+ZSmAmtn+Of8BQ1xfD3U+LpZm2Z1vg5gbNLUE3nwdupPglkv3PFCLhIGtdwTq+fue5HxhsvJ/
+SENTRY_AUTH_TOKEN=encrypted:BBQOb2JeKQnnfXh1/8G2PqQ980MB85sUR3x3fUAUnDBUxjmVxIZWkSNOr1um+TOGQkRGveClbusaKtpz+TIWFFx5P+yOkEHoKo9HarHD0jqd8zkNiPs/OiltT93BuxdCX5GVxDbzaiR4/ZApdu/60ma4f1ProQmm96c2cfYIhv2THbgExzI5ehv9R3nCr4T5ZvcpHETL/BUNdUdEiYS9SfmLFtjCArMo

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -183,20 +183,19 @@ pre-push:
     # ── Terraform ──
     # terraform apply 漏れ検出
     # infra/ の .tf 変更後に apply し忘れた状態での push を防止する
-    # .env.keys がなければ plan 実行不可のためブロック（infra/ を変更するなら復号キーが必要）
+    # ルートの .env.keys がなければ plan 実行不可のためブロック（infra/ を変更するなら復号キーが必要）
     - name: terraform-plan-check
       skip:
         # infra/ に変更がなければスキップ
         - run: git diff origin/main...HEAD --quiet -- 'infra/'
       timeout: 30s
       run: |
+        if [ ! -f ".env.keys" ]; then
+          echo "❌ ルートの .env.keys がないため apply 漏れを確認できません"
+          echo "👉 復号キーを管理者から取得してください"
+          exit 1
+        fi
         for dir in infra/*/; do
-          keys_file="${dir}.env.keys"
-          if [ ! -f "$keys_file" ]; then
-            echo "❌ $dir: .env.keys がないため apply 漏れを確認できません"
-            echo "👉 復号キーをパスワードマネージャー等から取得してください"
-            exit 1
-          fi
           [ -d "$dir.terraform" ] || (cd "$dir" && dotenvx run -- terraform init -input=false > /dev/null 2>&1)
           cd "$dir" && dotenvx run -- terraform plan -detailed-exitcode -no-color > /dev/null 2>&1
           exit_code=$?

--- a/mcp/.env
+++ b/mcp/.env
@@ -1,0 +1,25 @@
+#/-------------------[DOTENV_PUBLIC_KEY]--------------------/
+#/            public-key encryption for .env files          /
+#/       [how it works](https://dotenvx.com/encryption)     /
+#/----------------------------------------------------------/
+DOTENV_PUBLIC_KEY="03f83506aef1975a2728c7ad262c82a3e828be490a0a51ff14e3210d90fc91d578" # ../.env.keys
+
+# .env
+# MCP サーバー用の環境変数（dotenvx で暗号化済み）
+#
+# セットアップ手順:
+#   1. ルートの .env.keys を管理者から取得して配置
+#   2. dotenvx get で復号を確認
+#
+# 確認コマンド:
+#   cd mcp && dotenvx get | jq .               # 復号された全変数を整形表示
+#   cd mcp && dotenvx get SLACK_BOT_TOKEN      # 特定の変数のみ表示
+#
+# 新しい変数を追加する場合（mcp/ で実行）:
+#   1. .env に平文で追加
+#   2. dotenvx encrypt で暗号化
+
+# Slack Bot Token（MCP Server 用）
+# 取得先: https://api.slack.com/apps > Bot User OAuth Token
+# 権限: channels:history, channels:read, chat:write, reactions:write, users:read
+SLACK_BOT_TOKEN=encrypted:BEMjoeKnxAtFDYK2owfucdxCsSLgCJFsgJK/YC36pB7Q/4VEPKp9zIqjqAXPnzV6E9s8IrPP10f9NoXdaLMp4RzDyhFqRhRfzDMeOs0RPv2r8RwyfCg1wvZoNV39R6GQqUySuCbFKw65fzzNNpId5aQXKnbQ/sOP9e1S7GE2Jg6p08EW4HquOS83V1KTaTIK1LEx44MHRtMSZKI=

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,11 @@
 [settings]
 experimental = true
 
+# .env.keys から DOTENV_PRIVATE_KEY を環境変数にセット
+# dotenvx が自動的にこの環境変数を使って復号するため、-fk オプション不要
+[env]
+_.file = '.env.keys'
+
 [tools]
 node = "lts"
 bun = "latest"
@@ -14,15 +19,21 @@ gcloud = "latest" # Google Cloud CLI（OAuth 設定等）
 # ツールが既にインストール済みの場合はスキップされるため、cd 時の auto_install では発火しない
 [hooks]
 postinstall = """
-# dotenvx で暗号化された .env ファイルの復号キー（.env.keys）が揃っているかチェック
-# .env に DOTENV_PUBLIC_KEY が含まれていれば暗号化済みと判断し、対応する .env.keys の存在を確認する
-# .env.keys がなければ警告を表示（terraform plan 等が失敗するため）
-for env_file in $(git ls-files '*.env' --ignored --exclude-standard 2>/dev/null; git ls-files '*.env'); do
-  keys_file="${env_file%.env}.env.keys"
-  if grep -q 'DOTENV_PUBLIC_KEY' "$env_file" 2>/dev/null && [ ! -f "$keys_file" ]; then
+# ルートの .env.keys が存在するかチェック
+# 暗号化された .env ファイルの復号に必要（mise の [env] _.file で自動読み込み）
+if [ ! -f ".env.keys" ]; then
+  has_encrypted=0
+  for env_file in $(git ls-files '*.env'); do
+    if grep -q 'DOTENV_PUBLIC_KEY' "$env_file" 2>/dev/null; then
+      has_encrypted=1
+      break
+    fi
+  done
+  if [ "$has_encrypted" = "1" ]; then
     echo ""
-    echo "⚠️  $keys_file が見つかりません"
-    echo "   復号キーが必要です。詳細: $env_file"
+    echo "⚠️  ルートの .env.keys が見つかりません"
+    echo "   暗号化された .env ファイルの復号に必要です"
+    echo "👉 管理者から .env.keys を取得してルートに配置してください"
   fi
-done
+fi
 """


### PR DESCRIPTION
## Summary

- dotenvx の暗号化キーをディレクトリごとの個別管理からルート `.env.keys` による一元管理に移行
- mise.toml の `[env] _.file = '.env.keys'` で `DOTENV_PRIVATE_KEY` を自動ロードし、dotenvx コマンドの追加オプション（`-fk`）を不要に
- GitHub Secrets を 3 つ（`DOTENV_PRIVATE_KEY_WEB` / `DOTENV_PRIVATE_KEY_INFRA` / `DOTENV_PRIVATE_KEY_SENTRY`）→ `DOTENV_PRIVATE_KEY` 1 つに統一
- `scripts/setup-env-keys.ts` を削除（mise が代替）
- Cloudflare deploy ワークフローの GitHub Variables（`CLOUDFLARE_ACCOUNT_ID` / `CF_PAGES_PROJECT_NAME`）をハードコードに変更
- Slack MCP サーバーの設定を追加（`mcp/.env` + `.mcp.json`）

## マージ後の手動作業

1. GitHub Settings > Secrets に `DOTENV_PRIVATE_KEY` を新しい値で登録
2. 旧 Secrets を削除: `DOTENV_PRIVATE_KEY_WEB`, `DOTENV_PRIVATE_KEY_INFRA`, `DOTENV_PRIVATE_KEY_SENTRY`
3. 旧 Variables を削除: `CLOUDFLARE_ACCOUNT_ID`, `CF_PAGES_PROJECT_NAME`

## Test plan

- [x] 各ディレクトリで `dotenvx get` が正常に復号できること
- [x] `dotenvx run -- terraform plan` が infra/ で動作すること
- [x] lefthook pre-push 全チェック通過
- [x] lint / typecheck / test / build 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)