### PR TITLE
chore: Renovate digest 更新の PR からラベル運用を廃止

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -53,13 +53,13 @@
       automerge: false,
     },
 
-    // digest 更新は⚠️ラベル付きの draft PR にして目立たせる
+    // digest 更新は draft PR にして目立たせる
     // バージョン変更なしで SHA だけ変わった＝タグ改ざんの可能性があるため、
     // 通常の更新 PR と区別して慎重にレビューする
     {
       matchUpdateTypes: ["digest"],
       draftPR: true,
-      labels: ["⚠️ security-review"],
+      commitMessagePrefix: "chore(⚠️ digest):",
     },
 
     // pin タイプの更新を無効化（既存のキャレットレンジを維持）


### PR DESCRIPTION
## Summary

- Renovate の digest 更新 PR から `⚠️ security-review` ラベルを廃止
- 代わりに `commitMessagePrefix: "chore(⚠️ digest):"` で PR タイトルに視認性を確保
- draft PR は引き続き維持
- リポジトリから `⚠️ security-review` ラベル定義を削除済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)