### PR TITLE
feat: MSW ハンドラーを orpc-msw に移行し型安全化

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -76,6 +76,8 @@
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
+        "@orpc/contract": "^1.9.0",
+        "@orpc/openapi-client": "^1.9.0",
         "@storybook/addon-a11y": "^10.2.16",
         "@storybook/addon-docs": "^10.2.16",
         "@storybook/addon-mcp": "0.3.4",
@@ -89,6 +91,7 @@
         "@vitest/coverage-v8": "^4.0.18",
         "msw": "^2.10.3",
         "msw-storybook-addon": "^2.0.6",
+        "orpc-msw": "^0.1.0",
         "playwright": "^1.58.2",
         "reg-cli": "^0.18.14",
         "storybook": "^10.2.16",
@@ -979,6 +982,8 @@
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
+    "destr": ["destr@2.0.5", "", {}, "sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "doctrine": ["doctrine@3.0.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w=="],
@@ -1311,6 +1316,8 @@
 
     "openapi-types": ["openapi-types@12.1.3", "", {}, "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="],
 
+    "orpc-msw": ["orpc-msw@0.1.0", "", { "dependencies": { "destr": "^2.0.5", "ufo": "^1.6.3" }, "peerDependencies": { "@orpc/contract": "^1.8.7", "@orpc/openapi-client": "^1.8.7", "msw": "^2.11.1" } }, "sha512-XE3YFUmPTAx49Xl//bCb+ReA2JLeTjsmh3kuDHGyfOyPCfyZdsEN4a+dGkhiaSYH5xFKkyjzNc1BgGn7e6vLHw=="],
+
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
 
     "oxc-resolver": ["oxc-resolver@11.19.1", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.19.1", "@oxc-resolver/binding-android-arm64": "11.19.1", "@oxc-resolver/binding-darwin-arm64": "11.19.1", "@oxc-resolver/binding-darwin-x64": "11.19.1", "@oxc-resolver/binding-freebsd-x64": "11.19.1", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.19.1", "@oxc-resolver/binding-linux-arm-musleabihf": "11.19.1", "@oxc-resolver/binding-linux-arm64-gnu": "11.19.1", "@oxc-resolver/binding-linux-arm64-musl": "11.19.1", "@oxc-resolver/binding-linux-ppc64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-gnu": "11.19.1", "@oxc-resolver/binding-linux-riscv64-musl": "11.19.1", "@oxc-resolver/binding-linux-s390x-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-gnu": "11.19.1", "@oxc-resolver/binding-linux-x64-musl": "11.19.1", "@oxc-resolver/binding-openharmony-arm64": "11.19.1", "@oxc-resolver/binding-wasm32-wasi": "11.19.1", "@oxc-resolver/binding-win32-arm64-msvc": "11.19.1", "@oxc-resolver/binding-win32-ia32-msvc": "11.19.1", "@oxc-resolver/binding-win32-x64-msvc": "11.19.1" } }, "sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg=="],
@@ -1584,6 +1591,8 @@
     "type-plus": ["type-plus@8.0.0-beta.7", "", { "dependencies": { "tersify": "^3.11.1", "unpartial": "^1.0.4" } }, "sha512-LTV9UqBJ20I48Ba2L8N25EOowtrs40MLzsqQFfvAXnPAN9z0ny4CjduFfNIfW7euZ6wr6ImShEtrhR1virHiNw=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
     "ultracite": ["ultracite@7.2.5", "", { "dependencies": { "@clack/prompts": "^1.1.0", "commander": "^14.0.3", "deepmerge": "^4.3.1", "glob": "^13.0.6", "jsonc-parser": "^3.3.1", "nypm": "^0.6.5" }, "peerDependencies": { "oxlint": "^1.0.0" }, "optionalPeers": ["oxlint"], "bin": { "ultracite": "dist/index.js" } }, "sha512-Fw+V7P/gzTcVz6wmyYxaw8AGIOYDOilzwEiQq7pDGjrHwqdSzNrzevh1wxk0FTYfSHhk5a+wX02/Ayu8IK/x0A=="],
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,8 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@orpc/contract": "^1.9.0",
+    "@orpc/openapi-client": "^1.9.0",
     "@storybook/addon-a11y": "^10.2.16",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-mcp": "0.3.4",
@@ -46,6 +48,7 @@
     "@vitest/coverage-v8": "^4.0.18",
     "msw": "^2.10.3",
     "msw-storybook-addon": "^2.0.6",
+    "orpc-msw": "^0.1.0",
     "playwright": "^1.58.2",
     "reg-cli": "^0.18.14",
     "storybook": "^10.2.16",

--- a/packages/ui/src/mocks/handlers.ts
+++ b/packages/ui/src/mocks/handlers.ts
@@ -1,23 +1,36 @@
 /**
- * MSW ハンドラー定義
+ * MSW ハンドラー定義（orpc-msw 版）
  *
- * Storybook のストーリーで API レスポンスをモックするための MSW ハンドラー。
- * msw-storybook-addon の parameters.msw.handlers に渡して使用する。
- *
+ * orpc-msw の createMSWUtilities() を使い、コントラクトから型安全な MSW ハンドラーを生成する。
  * createTodoHandlers() にモックデータを渡すことで、ストーリーごとに
  * 異なる API レスポンスを返すことができる（空リスト、全完了済み等）。
  *
- * 設計判断:
- * - orpc-msw（v0.1.0）を使えばコントラクトから MSW ハンドラーを自動生成できるが、
- *   v0.1.0 と初期段階のため安定性を優先して手動定義を選択した（未検証）
- * - エンドポイントが3つと少なく手動でも負担が小さいため、現時点では十分
- * - コントラクトの Todo 型を直接参照することで、スキーマ変更時に型エラーで検知可能
+ * orpc-msw を使うメリット（手動 MSW ハンドラーとの比較）:
+ * - パスの手書きが不要: コントラクトの path 定義から MSW ルーティングを自動生成する
+ *   （例: コントラクトの `/todos/{id}` → MSW の `/todos/:id` への変換も自動）
+ * - input の型推論: ハンドラーの引数 ({ input }) がコントラクトの入力スキーマから推論される
+ * - output の型チェック: 返り値がコントラクトの出力スキーマと一致しないと型エラーになる
+ * - コントラクト変更への追従: パス変更・フィールド追加時にコンパイルエラーで検知できる
+ *
+ * デメリット・注意点:
+ * - orpc-msw は v0.1.0（最終更新 2026-01-20）で更新頻度が低い
+ * - peer dependency に @orpc/contract + @orpc/openapi-client が追加で必要
+ * - 戻り値の型推論で HttpHandler の明示的アノテーションが必要（tsgo の型推論制約）
+ * - エラーレスポンス等のカスタムステータスコードは Response オブジェクトを直接返す必要がある
  */
+import { contract } from "@storybook-vrt-sample/api-contract";
 import type { Todo } from "@storybook-vrt-sample/api-contract";
-import { http, HttpResponse } from "msw";
+import type { HttpHandler } from "msw";
+import { createMSWUtilities } from "orpc-msw";
 
 /** API サーバーのベース URL（apps/api のデフォルトポート） */
 const API_BASE = "http://localhost:3001/api";
+
+/** コントラクトから MSW ユーティリティを生成 */
+const msw = createMSWUtilities({
+  router: contract,
+  baseUrl: API_BASE,
+});
 
 export const defaultTodos: Todo[] = [
   { id: "1", title: "Buy groceries", completed: false },
@@ -25,22 +38,20 @@ export const defaultTodos: Todo[] = [
   { id: "3", title: "Review PR", completed: false },
 ];
 
-export const createTodoHandlers = (todos: Todo[] = defaultTodos) => [
-  http.get(`${API_BASE}/todos`, () => HttpResponse.json(todos)),
-  http.post(`${API_BASE}/todos`, async ({ request }) => {
-    const body = (await request.json()) as { title: string };
-    const newTodo: Todo = {
-      id: crypto.randomUUID(),
-      title: body.title,
-      completed: false,
-    };
-    return HttpResponse.json(newTodo, { status: 201 });
-  }),
-  http.patch(`${API_BASE}/todos/:id`, ({ params }) => {
-    const todo = todos.find((t) => t.id === params["id"]);
+export const createTodoHandlers = (
+  todos: Todo[] = defaultTodos
+): HttpHandler[] => [
+  msw.todo.list.handler(() => todos),
+  msw.todo.create.handler(({ input }) => ({
+    id: crypto.randomUUID(),
+    title: input.title,
+    completed: false,
+  })),
+  msw.todo.toggle.handler(({ input }) => {
+    const todo = todos.find((t) => t.id === input.id);
     if (!todo) {
-      return HttpResponse.json({ message: "Not found" }, { status: 404 });
+      return Response.json({ message: "Not found" }, { status: 404 });
     }
-    return HttpResponse.json({ ...todo, completed: !todo.completed });
+    return { ...todo, completed: !todo.completed };
   }),
 ];


### PR DESCRIPTION
## Summary

- 手動定義の MSW ハンドラー（`http.get/post/patch`）を orpc-msw の `createMSWUtilities()` に置き換え
- コントラクトからパス・入出力型を自動生成し、手書きのパス定義と型の不一致リスクを排除
- orpc-msw v0.1.0 の採用判断と、メリット・デメリットを JSDoc コメントに記載

## 背景

前 PR (#73) では「orpc-msw は v0.1.0 で初期段階のため安定性を優先して手動定義を選択」としていたが、
本ブランチで実際に検証した結果、エンドポイント3つの規模では問題なく動作し、型安全性のメリットが上回ると判断した。

## Test plan

- [x] `bun run typecheck` パス
- [x] `bun run lint:fix` パス
- [x] lefthook pre-push（unit-test, storybook:test, e2e-test, build 等）全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)