### PR TITLE
feat: oRPC クライアント導入 + API URL 環境変数化

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -69,6 +69,9 @@
       "version": "0.0.0",
       "dependencies": {
         "@heroicons/react": "^2.2.0",
+        "@orpc/client": "^1.9.0",
+        "@orpc/contract": "^1.9.0",
+        "@orpc/openapi-client": "^1.9.0",
         "@storybook-vrt-sample/api-contract": "workspace:*",
         "clsx": "^2.1.1",
         "react": "^19.2.4",
@@ -76,8 +79,6 @@
         "tailwind-merge": "^3.5.0",
       },
       "devDependencies": {
-        "@orpc/contract": "^1.9.0",
-        "@orpc/openapi-client": "^1.9.0",
         "@storybook/addon-a11y": "^10.2.16",
         "@storybook/addon-docs": "^10.2.16",
         "@storybook/addon-mcp": "0.3.4",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -26,6 +26,9 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
+    "@orpc/client": "^1.9.0",
+    "@orpc/contract": "^1.9.0",
+    "@orpc/openapi-client": "^1.9.0",
     "@storybook-vrt-sample/api-contract": "workspace:*",
     "clsx": "^2.1.1",
     "react": "^19.2.4",
@@ -33,8 +36,6 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
-    "@orpc/contract": "^1.9.0",
-    "@orpc/openapi-client": "^1.9.0",
     "@storybook/addon-a11y": "^10.2.16",
     "@storybook/addon-docs": "^10.2.16",
     "@storybook/addon-mcp": "0.3.4",

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -1,0 +1,25 @@
+/**
+ * oRPC API クライアント
+ *
+ * コントラクトから型安全な API クライアントを生成する。
+ * OpenAPILink を使用するため、サーバー側が OpenAPI 形式（@orpc/openapi）で
+ * ルーティングしていることが前提。
+ */
+import { createORPCClient } from "@orpc/client";
+import type { ContractRouterClient } from "@orpc/contract";
+import { OpenAPILink } from "@orpc/openapi-client/fetch";
+import { contract } from "@storybook-vrt-sample/api-contract";
+
+/** API ベース URL のデフォルト値（ローカル開発用） */
+export const DEFAULT_API_BASE_URL = "http://localhost:3001/api";
+
+/** コントラクトから推論された型安全なクライアント型 */
+export type TodoApiClient = ContractRouterClient<typeof contract>;
+
+/** 指定した baseUrl で oRPC クライアントを生成する */
+export const createTodoApiClient = (
+  baseUrl: string = DEFAULT_API_BASE_URL
+): TodoApiClient => {
+  const link = new OpenAPILink(contract, { url: baseUrl });
+  return createORPCClient<TodoApiClient>(link);
+};

--- a/packages/ui/src/components/TodoList/TodoList.tsx
+++ b/packages/ui/src/components/TodoList/TodoList.tsx
@@ -1,30 +1,29 @@
 /**
  * TodoList コンポーネント
  *
- * API サーバー（apps/api）から TODO を取得・作成・トグルするサンプルコンポーネント。
- * Storybook では msw-storybook-addon 経由で MSW がリクエストをインターセプトし、
- * モックデータを返すため、API サーバーの起動は不要。
+ * oRPC クライアント経由で API サーバーと通信する TODO 管理コンポーネント。
+ * apiBaseUrl を props で受け取ることで、環境ごとに接続先を切り替えられる。
  *
- * 本番環境での使用は想定していない（API クライアントの抽象化、エラーハンドリング等が未実装）。
+ * - ローカル開発: デフォルトの localhost:3001
+ * - Storybook: MSW がインターセプトするため URL は問わない
+ * - ステージング/本番: apps/web から環境変数で注入
  */
 import type { Todo } from "@storybook-vrt-sample/api-contract";
-import { useCallback, useEffect, useState } from "react";
-
-/** API サーバーのベース URL（apps/api のデフォルトポート） */
-const API_BASE = "http://localhost:3001/api";
+import { createTodoApiClient } from "@ui/api/client";
+import type { TodoApiClient } from "@ui/api/client";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /** TODO の CRUD 操作をまとめたカスタムフック */
-const useTodos = () => {
+const useTodos = (client: TodoApiClient) => {
   const [todos, setTodos] = useState<Todo[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchTodos = useCallback(async () => {
     setLoading(true);
-    const res = await fetch(`${API_BASE}/todos`);
-    const data = (await res.json()) as Todo[];
+    const data = await client.todo.list();
     setTodos(data);
     setLoading(false);
-  }, []);
+  }, [client]);
 
   useEffect(() => {
     const load = async () => {
@@ -36,22 +35,18 @@ const useTodos = () => {
 
   const toggle = useCallback(
     async (id: string) => {
-      await fetch(`${API_BASE}/todos/${id}`, { method: "PATCH" });
+      await client.todo.toggle({ id });
       await fetchTodos();
     },
-    [fetchTodos]
+    [client, fetchTodos]
   );
 
   const create = useCallback(
     async (title: string) => {
-      await fetch(`${API_BASE}/todos`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ title }),
-      });
+      await client.todo.create({ title });
       await fetchTodos();
     },
-    [fetchTodos]
+    [client, fetchTodos]
   );
 
   return { todos, loading, toggle, create };
@@ -92,8 +87,9 @@ const TodoItem = ({
   );
 };
 
-export const TodoList = () => {
-  const { todos, loading, toggle, create } = useTodos();
+export const TodoList = ({ apiBaseUrl }: { apiBaseUrl?: string }) => {
+  const client = useMemo(() => createTodoApiClient(apiBaseUrl), [apiBaseUrl]);
+  const { todos, loading, toggle, create } = useTodos(client);
   const [newTitle, setNewTitle] = useState("");
 
   const handleCreate = useCallback(async () => {

--- a/packages/ui/src/mocks/handlers.ts
+++ b/packages/ui/src/mocks/handlers.ts
@@ -20,16 +20,14 @@
  */
 import { contract } from "@storybook-vrt-sample/api-contract";
 import type { Todo } from "@storybook-vrt-sample/api-contract";
+import { DEFAULT_API_BASE_URL } from "@ui/api/client";
 import type { HttpHandler } from "msw";
 import { createMSWUtilities } from "orpc-msw";
-
-/** API サーバーのベース URL（apps/api のデフォルトポート） */
-const API_BASE = "http://localhost:3001/api";
 
 /** コントラクトから MSW ユーティリティを生成 */
 const msw = createMSWUtilities({
   router: contract,
-  baseUrl: API_BASE,
+  baseUrl: DEFAULT_API_BASE_URL,
 });
 
 export const defaultTodos: Todo[] = [


### PR DESCRIPTION
## Summary

- TodoList の `fetch` 直書きを oRPC クライアント（`createORPCClient` + `OpenAPILink`）に置き換え
- `apiBaseUrl` props で環境ごとの API 接続先を切り替え可能に
- `API_BASE` のハードコード2箇所を共通定数 `DEFAULT_API_BASE_URL` に統一
- `@orpc/client` を dependencies に追加、`@orpc/contract`・`@orpc/openapi-client` を devDependencies → dependencies に移動

## 設計判断

packages/ui が Next.js（`process.env.NEXT_PUBLIC_*`）や Vite（`import.meta.env.VITE_*`）の環境変数規約に依存しないよう、`apiBaseUrl` を props で注入する設計にした。apps/web 側で `process.env.NEXT_PUBLIC_API_URL` を渡す想定。

Storybook では MSW がリクエストをインターセプトするため、`apiBaseUrl` を渡さなくても（デフォルト値のまま）正常に動作する。

## Test plan

- [x] `bun run typecheck` パス
- [x] `bun run lint:fix` パス
- [x] `bun run storybook:test` 全58テストパス（MSW 経由の通信を確認）
- [x] lefthook pre-push 全チェックパス

closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)