### PR TITLE
docs: API Workers アイコン変更 + トークン権限コメント更新 + required checks 追加

### DIFF
--- a/.github/workflows/api-cloudflare-workers-deploy.yml
+++ b/.github/workflows/api-cloudflare-workers-deploy.yml
@@ -9,10 +9,11 @@
 #
 # 必要な設定:
 #   Secrets:
-#     CLOUDFLARE_API_TOKEN    — Cloudflare API Token
-#       権限: Workers Scripts: Edit
+#     CLOUDFLARE_API_TOKEN    — Cloudflare API Token「GitHub Actions - Cloudflare Pages / Workers」
+#       権限: Cloudflare Pages: Edit, Workers Scripts: Edit
+#       ※ Storybook Cloudflare Deploy と同一トークンを共有
 # ==============================================
-name: 🚀 API Cloudflare Workers Deploy
+name: ⚡ API Cloudflare Workers Deploy
 
 on:
   push:
@@ -33,7 +34,7 @@ permissions:
 
 jobs:
   changes:
-    name: 🚀 API Workers / changes
+    name: ⚡ API Workers / changes
     if: github.event_name != 'pull_request' || !github.event.pull_request.draft
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -52,7 +53,7 @@ jobs:
               - '.github/workflows/api-cloudflare-workers-deploy.yml'
 
   deploy:
-    name: 🚀 Deploy API to Cloudflare Workers
+    name: ⚡ Deploy API to Cloudflare Workers
     needs: changes
     if: github.event_name != 'pull_request' || needs.changes.outputs.should-run == 'true'
     runs-on: ubuntu-latest
@@ -89,7 +90,7 @@ jobs:
       - name: Add summary
         run: |
           ENV=${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && 'production' || 'staging' }}
-          echo "## 🚀 API Cloudflare Workers ($ENV)" >> $GITHUB_STEP_SUMMARY
+          echo "## ⚡ API Cloudflare Workers ($ENV)" >> $GITHUB_STEP_SUMMARY
           echo "Deploy completed for environment: **$ENV**" >> $GITHUB_STEP_SUMMARY
 
       - name: Comment PR with deploy info
@@ -98,6 +99,6 @@ jobs:
         with:
           header: cloudflare-api-workers
           message: |
-            ## 🚀 API Cloudflare Workers Preview
+            ## ⚡ API Cloudflare Workers Preview
 
             API が staging 環境にデプロイされました。

--- a/.github/workflows/storybook-cloudflare-deploy.yml
+++ b/.github/workflows/storybook-cloudflare-deploy.yml
@@ -11,8 +11,8 @@
 #
 # 必要な設定:
 #   Secrets:
-#     CLOUDFLARE_API_TOKEN    — Cloudflare API Token「GitHub Actions - Cloudflare Pages」
-#       権限: Cloudflare Pages: Edit
+#     CLOUDFLARE_API_TOKEN    — Cloudflare API Token「GitHub Actions - Cloudflare Pages / Workers」
+#       権限: Cloudflare Pages: Edit, Workers Scripts: Edit
 #       ※ Terraform 用トークン（infra/cloudflare-access/.env で管理）とは別トークン
 #   初回セットアップ:
 #     bunx wrangler pages project create <project-name> --production-branch main

--- a/README.md
+++ b/README.md
@@ -289,7 +289,7 @@ PR 作成時（Ready for review）に GitHub Actions が自動実行されます
 - 🧪 **E2E テスト** (`web-e2e.yml`): 全 PR で起動し、`apps/web/` または `packages/ui/` の変更時のみ実行（変更なしの場合はジョブ skip = pass）
 - 🎨 **Storybook Chromatic Deploy** (`storybook-chromatic-deploy.yml`): main マージ時・PR 時に Storybook を Chromatic へデプロイ（PR 時は `packages/ui/` 変更時のみ）
 - ☁️ **Storybook Cloudflare Deploy** (`storybook-cloudflare-deploy.yml`): main マージ時・PR 時に Storybook を Cloudflare Pages へデプロイ（PR 時は `packages/ui/` 変更時のみ、Cloudflare Access による認証付き）
-- 🚀 **API Cloudflare Workers Deploy** (`api-cloudflare-workers-deploy.yml`): main マージ時は production、PR 時は staging に API をデプロイ（`apps/api/` または `packages/api-contract/` 変更時のみ）
+- ⚡ **API Cloudflare Workers Deploy** (`api-cloudflare-workers-deploy.yml`): main マージ時は production、PR 時は staging に API をデプロイ（`apps/api/` または `packages/api-contract/` 変更時のみ）
 - 🧹 **Cleanup GitHub Pages** (`github-pages-cleanup.yml`): PR クローズ時に gh-pages の容量をチェックし、800MB 超過時に古いレポートを削除
 
 > **Note:** paths フィルタ付きワークフロー（VRT, E2E, Chromatic, Cloudflare, Infra CI）は全 PR で起動し、[AurorNZ/paths-filter](https://github.com/AurorNZ/paths-filter) でジョブレベル skip する設計です。ワークフローレベルの `paths:` だとチェックが「存在しない」状態になり required status checks でマージがブロックされますが、ジョブレベル skip は GitHub 上で pass 扱いになるためこの問題を回避できます。


### PR DESCRIPTION
## Summary

- API Workers デプロイのアイコンを 🚀 → ⚡ に変更（☁️ Cloudflare Pages との区別）
- `CLOUDFLARE_API_TOKEN` の権限コメントを両ワークフローで統一（Pages Edit + Workers Scripts Edit）
- main ブランチの required status checks に `⚡ API Workers / changes` と `⚡ Deploy API to Cloudflare Workers` を追加

## 背景

#86 で API Workers デプロイを追加したが、required status checks に含まれていなかったため、CI 失敗でも auto-merge されてしまった。また、API Token に Workers Scripts Edit 権限を追加したため、コメントも実態に合わせて更新した。

## Test plan

- [x] required status checks を `gh api` で更新済み
- [x] コメントのみの変更のため、型チェック・lint への影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)