### PR TITLE
fix: Web デプロイで wrangler-action の packageManager を bunx に指定

### DIFF
--- a/.github/workflows/web-cloudflare-deploy.yml
+++ b/.github/workflows/web-cloudflare-deploy.yml
@@ -95,6 +95,7 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: 95d6c4c8536abbe739beadf65c380ae4
           workingDirectory: apps/web
+          packageManager: bunx
           command: deploy
 
       # ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- wrangler-action がデフォルトで `npx wrangler` を実行するが、bun モノレポでは `npx` がパスを解決できずエラーになっていた
- `packageManager: bunx` を指定して `bunx wrangler` 経由で実行するように修正

### 原因

PR #106 のマージ後、🌐 Web Cloudflare Deploy が `could not determine executable to run` で失敗。
`wrangler` は `apps/web/node_modules` にあるが、`npx` は bun のモノレポ構造を解決できなかった。

## Test plan

- [ ] CI の 🌐 Deploy Web to Cloudflare Workers がパスすること

🤖 Generated with [Claude Code](https://claude.com/claude-code)