### PR TITLE
chore: ルート tsconfig を esnext + bundler に統一

### DIFF
--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,11 +9,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist",
-    // Bun はバンドラーとして動作するため esnext + bundler が適切。
-    // ルートの nodenext を継承すると .js 拡張子が必須になり、
-    // api-contract の拡張子なし import が typecheck で失敗する。
-    "module": "esnext",
-    "moduleResolution": "bundler",
     "types": ["bun", "@cloudflare/workers-types"]
   },
   "include": ["src"]

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -6,10 +6,6 @@
   // - ルートの strict 系オプションを緩める変更は禁止（型安全性が低下する）
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // バンドラー環境向けにモジュール設定を上書き（Next.js / Turbopack）
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-
     // ブラウザ向け型定義ライブラリ
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
 

--- a/packages/api-contract/tsconfig.json
+++ b/packages/api-contract/tsconfig.json
@@ -8,9 +8,6 @@
   //   ルートの tsconfig.json をそのまま継承し、追加の lib や types は不要
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // バンドラー環境向けにモジュール設定を上書き（Turbopack / Vite から直接参照されるため）
-    "module": "ESNext",
-    "moduleResolution": "bundler",
     "rootDir": "./src",
     "outDir": "./dist"
   },

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -8,10 +8,6 @@
   //   VS Code の Language Server で型チェックされる
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    // バンドラー環境向けにモジュール設定を上書き（Vite / Storybook）
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-
     // ブラウザ向け型定義ライブラリ
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,10 @@
     // "outDir": "./dist",
 
     // Environment Settings
-    // See also https://aka.ms/tsconfig/module
-    "module": "nodenext",
+    // 全ワークスペースがバンドラー経由（Next.js Turbopack, Vite, Bun）で実行されるため
+    // esnext + bundler を使用。nodenext は Node.js で直接実行する場合や npm 公開ライブラリ向け。
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "target": "esnext",
     "types": [],
     // For nodejs:


### PR DESCRIPTION
## 概要

ルートの tsconfig の `module` を `nodenext` → `esnext`、`moduleResolution` を `bundler` に変更し、各ワークスペースで重複していた上書きを削除。

## 背景

全ワークスペースがバンドラー経由で実行される構成:
- apps/web: Next.js (Turbopack)
- apps/api: Bun / Cloudflare Workers
- packages/ui: Storybook (Vite)
- packages/api-contract: ライブラリ（消費側がバンドル）

にもかかわらず、ルートは tsgo --init のデフォルト（`nodenext`）のままだった。全ワークスペースが `module: "ESNext" + moduleResolution: "bundler"` で個別に上書きしていたため、ルートの設定は実質使われていなかった。

`nodenext` は Node.js で直接 `.mjs` を実行する場合や npm 公開ライブラリ向けの設定であり、このモノレポでは不要。

## 変更内容

- `tsconfig.json`（ルート）: `module: "esnext"` + `moduleResolution: "bundler"` に変更
- `apps/web/tsconfig.json`: `module` / `moduleResolution` の上書きを削除
- `apps/api/tsconfig.json`: 同上
- `packages/api-contract/tsconfig.json`: 同上
- `packages/ui/tsconfig.json`: 同上
